### PR TITLE
chore: add tuple-to-union type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -18,3 +18,15 @@ export type DeepReadonly<T extends object> = {
             ? DeepReadonly<T[Property]>
             : T[Property];
 };
+
+/**
+ * Creates a union type from the literal values of a constant string or number array.
+ * This is useful for representing a set of allowed values based on the array elements
+ * 
+ * @example
+ * type StringUnion = ["1", "2", "3"]
+ * type Union = TypleToUnion<StringUnion> // "1" | "2" | "3"
+ */
+export type TupleToUnion<T extends readonly any[]> = T extends [infer Item, ...infer Spreed]
+    ? Item | TupleToUnion<Spreed>
+    : never;


### PR DESCRIPTION
## Description
This pull request adds a new utility type that allows creating a union type from the literal values of a constant array.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->