### PR TITLE
feat: add size, last and pop utility types

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -33,23 +33,25 @@ export type TupleToUnion<T extends readonly any[]> = T extends [infer Item, ...i
 
 
 /**
- * Returns the size of an array
+ * Gets the length (size) of an array.
+ *
  * @example
- * const nums = [1, 2, 3, 4, 5]
- * type SizeNums = Size<nums> // 5
+ * const numbers: number[] = [1, 2, 3, 4, 5];
+ * type SizeOfNumbers = Size<typeof numbers>; // SizeOfNumbers = 5
  */
 export type Size<T extends any[]> = T extends any[] ? T["length"] : 0;
 
 
 /**
- * Get the last element within an array otherwise it return never
+ * Gets the type of the last element in an array, or `never` if the array is empty.
  * @example
  * type LastItem = Last<1, 2, 3, 4> // 4
  */
 export type Last<T extends any[]> = T extends [...any, infer Last] ? Last : never;
 
 /**
- * Pops the last item of an array and returns the first element without the last item.
+ * Removes the last element from an array and returns a new array type with all elements 
+ * except the last. If the array is empty, returns an empty array type
  * @example
  * type PopStr = Pop<["a", "b", "c"]> // ["a", "b"]
  * type PopNums = Pop<[1, 2, 3]> // [1, 2]

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -30,3 +30,28 @@ export type DeepReadonly<T extends object> = {
 export type TupleToUnion<T extends readonly any[]> = T extends [infer Item, ...infer Spreed]
     ? Item | TupleToUnion<Spreed>
     : never;
+
+
+/**
+ * Returns the size of an array
+ * @example
+ * const nums = [1, 2, 3, 4, 5]
+ * type SizeNums = Size<nums> // 5
+ */
+export type Size<T extends any[]> = T extends any[] ? T["length"] : 0;
+
+
+/**
+ * Get the last element within an array otherwise it return never
+ * @example
+ * type LastItem = Last<1, 2, 3, 4> // 4
+ */
+export type Last<T extends any[]> = T extends [...any, infer Last] ? Last : never;
+
+/**
+ * Pops the last item of an array and returns the first element without the last item.
+ * @example
+ * type PopStr = Pop<["a", "b", "c"]> // ["a", "b"]
+ * type PopNums = Pop<[1, 2, 3]> // [1, 2]
+ */
+export type Pop<T extends any[]> = T extends [...infer Items, any] ? Items : [];


### PR DESCRIPTION
## Description
This pull request adds three new utility types to the package. These types can be used to operate on arrays. The utility types added are:
- Last: : Retrieves the last element of a tuple type.
- Pop: Removes the last element of a tuple type.
- Size: Determines the size of a given type.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->