### PR TITLE
feat: add utility types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,11 @@ export type {
     Exclude, 
     Includes, 
     Parameters, 
-    Pick
+    Pick,
+    Omit,
+    Trim,
+    TrimLeft,
+    TrimRight
 } from "./utility-types"
 
 export type { 
@@ -17,12 +21,18 @@ export type {
     Nullish, 
     Primitive,
     PrimitiveNullish,
-    WhiteSpace
+    WhiteSpaces
 } from "./types"
 
 export {
     isPrimitive,
-    isPrimitiveNullish
+    isPrimitiveNullish,
+    isArray,
+    isBoolean,
+    isNullish,
+    isNumber,
+    isObject,
+    isString
 } from "./validate-types"
 
 export type {

--- a/src/types.ts
+++ b/src/types.ts
@@ -37,4 +37,4 @@ export type Primitive = Omit<PrimitiveNullish, "null" | "undefined">;
  * Represents a whitespace character: space, newline, tab, carriage return, form feed,
  * line separator, or paragraph separator.
  */
-export type WhiteSpace = " " | "\n" | "\t" | "\r" | "\f" | "\u2028" | "\u2029"
+export type WhiteSpaces = " " | "\n" | "\t" | "\r" | "\f" | "\u2028" | "\u2029"

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,4 +1,5 @@
 import { Equals } from "./test";
+import { WhiteSpaces } from "./types";
 
 /**
  * Utility type that transforms an object to have each property on a new line
@@ -99,3 +100,44 @@ export type Includes<T extends any[], U> = T extends [infer Compare, ...infer It
 		? true 
 		: Includes<Items, U>
 	: false;
+
+/**
+ * Creates a new type that omits properties from an object type based on another type
+ * @example
+ * type Person = { name: string; age: number; email: string };
+ * type NoEmailPerson = Omit<Person, "email">;  // NoEmailPerson = { name: string; age: number }
+ */
+export type Omit<T extends object, U> = {
+	[Property in keyof T as Property extends U ? never : Property]: T[Property]
+};
+
+/**
+ * Removes leading whitespace characters from a string type
+ * @example
+ * type Str = "  hello world  ";
+ * type TrimmedLeft = TrimLeft<Str>; // TrimmedLeft = "hello world  "
+ */
+export type TrimLeft<S extends string> = S extends `${WhiteSpaces}${infer Characters}`
+	? TrimLeft<Characters>
+	: S
+/**
+ * Removes trailing whitespace characters from a string type
+ * @example
+ * type Str = "hello world  ";
+ * type TrimmedRight = TrimRight<Str>; // TrimmedRight = "hello world"
+ */
+export type TrimRight<S extends string> = S extends `${infer Char}${WhiteSpaces}`
+	? TrimRight<Char>
+	: S;
+
+/**
+ * Removes leading and trailing whitespace characters from a string type
+ * @example
+ * type Str = "  hello world  ";
+ * type Trimmed = Trim<Str>; // Trimmed = "hello world"
+ */
+export type Trim<S extends string> = S extends `${WhiteSpaces}${infer Characters}`
+	? Trim<Characters>
+	: S extends `${infer Char}${WhiteSpaces}`
+		? Trim<Char>
+		: S;


### PR DESCRIPTION
## Description
This pull request introduces four new utility types for the package, designed to work with objects and strings. This PR includes documentation for each new type and the respective imports in the index.ts file. The added utility types are

- Omit: Removes specified keys from an object type.
- TrimLeft: Trims whitespace from the left side of a string type.
- TrimRight: Trims whitespace from the right side of a string type.
- Trim: Trims whitespace from both sides of a string type.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->