### PR TITLE
refactor(types): replace `any` with `unknown`

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,5 +1,5 @@
 import type { Equals } from "./test";
-import type { LetterToLowercase, LetterToUppercase, WhiteSpaces } from "./types";
+import type { ArgsFunction, LetterToLowercase, LetterToUppercase, WhiteSpaces } from "./types";
 
 /**
  * Utility type that transforms an object to have each property on a new line
@@ -30,7 +30,7 @@ export type DeepReadonly<T extends object> = {
  * type StringUnion = ["1", "2", "3"]
  * type Union = TypleToUnion<StringUnion> // "1" | "2" | "3"
  */
-export type TupleToUnion<T extends readonly any[]> = T extends [infer Item, ...infer Spreed]
+export type TupleToUnion<T extends readonly unknown[]> = T extends [infer Item, ...infer Spreed]
     ? Item | TupleToUnion<Spreed>
     : never;
 
@@ -42,7 +42,7 @@ export type TupleToUnion<T extends readonly any[]> = T extends [infer Item, ...i
  * const numbers: number[] = [1, 2, 3, 4, 5];
  * type SizeOfNumbers = Size<typeof numbers>; // SizeOfNumbers = 5
  */
-export type Size<T extends any[]> = T extends any[] ? T["length"] : 0;
+export type Size<T extends unknown[]> = T extends unknown[] ? T["length"] : 0;
 
 
 /**
@@ -50,7 +50,7 @@ export type Size<T extends any[]> = T extends any[] ? T["length"] : 0;
  * @example
  * type LastItem = Last<1, 2, 3, 4> // 4
  */
-export type Last<T extends any[]> = T extends [...any, infer Last] ? Last : never;
+export type Last<T extends unknown[]> = T extends [...any, infer Last] ? Last : never;
 
 /**
  * Removes the last element from an array and returns a new array type with all elements 
@@ -59,7 +59,7 @@ export type Last<T extends any[]> = T extends [...any, infer Last] ? Last : neve
  * type PopStr = Pop<["a", "b", "c"]> // ["a", "b"]
  * type PopNums = Pop<[1, 2, 3]> // [1, 2]
  */
-export type Pop<T extends any[]> = T extends [...infer Items, any] ? Items : [];
+export type Pop<T extends unknown[]> = T extends [...infer Items, unknown] ? Items : [];
 
 /**
  * Exclude properties of type `U` from type `T`
@@ -69,8 +69,8 @@ export type Exclude<T, U> = T extends U ? never : T;
 /**
  * Get the type of the resolved value of a PromiseLike object.
  */
-export type Awaited<T extends PromiseLike<any>> = T extends PromiseLike<infer R> 
-	? R extends PromiseLike<any> 
+export type Awaited<T extends PromiseLike<unknown>> = T extends PromiseLike<infer R>
+	? R extends PromiseLike<unknown>
 		? Awaited<R>
 		: R
 	: never;
@@ -83,7 +83,7 @@ export type Awaited<T extends PromiseLike<any>> = T extends PromiseLike<infer R>
  * }
  * type AddParams = Parameters<typeof add>; // AddParams = [number, number]
  */
-export type Parameters<T extends (...args: any) => void> = T extends (...args: infer P) => void ? P : never;
+export type Parameters<T extends ArgsFunction> = T extends (...args: infer P) => void ? P : never;
 
 /**
  * Create a new type with a subset of properties from an object
@@ -95,7 +95,7 @@ export type Pick<T extends object, K extends keyof T> = {
 /**
  * Check if a value exists within a tuple and is equal to a specific value.as
  */
-export type Includes<T extends any[], U> = T extends [infer Compare, ...infer Items]
+export type Includes<T extends unknown[], U> = T extends [infer Compare, ...infer Items]
 	? Equals<Compare, U> extends true
 		? true 
 		: Includes<Items, U>

--- a/src/validate-types.ts
+++ b/src/validate-types.ts
@@ -11,7 +11,7 @@ const primitives = ["number", "string", "boolean", "bigint", "symbol"];
  * @param value The value to check
  * @returns {boolean} `true` if the value is a primitive type, `false` otherwise
  */
-export const isPrimitive = (value: any): value is Primitive => {
+export const isPrimitive = (value: unknown): value is Primitive => {
     return primitives.some(primitive => typeof value === primitive)
 };
 
@@ -21,28 +21,28 @@ export const isPrimitive = (value: any): value is Primitive => {
  * @param value The value to check
  * @returns {boolean} `true` if the value is a primitive type with nullish values, `false` otherwise
  */
-export const isPrimitiveNullish = (value: any): value is PrimitiveNullish => isNullish(value) || isPrimitive(value);
+export const isPrimitiveNullish = (value: unknown): value is PrimitiveNullish => isNullish(value) || isPrimitive(value);
 
 /**
  * Checks if a value is nullish (null or undefined).
  * @param value The value to check
  * @returns `true` if the value is nullish, `false` otherwise
  */
-export const isNullish = (value: any): value is Nullish => value === null || value === undefined
+export const isNullish = (value: unknown): value is Nullish => value === null || value === undefined
 
 /**
  * Checks if a value is a boolean type
  * @param value The value to check
  * @returns {boolean} `true` if the value is a boolean, `false` otherwise
  */
-export const isBoolean = (value: any): value is boolean => typeof value === "boolean";
+export const isBoolean = (value: unknown): value is boolean => typeof value === "boolean";
 
 /**
  * Checks if a value is a string type
  * @param value The value to check
  * @returns {boolean} `true` if the value is a string, `false` otherwise
  */
-export const isString = (value: any): value is string => typeof value === "string";
+export const isString = (value: unknown): value is string => typeof value === "string";
 
 /**
  *Checks if a value is a number type
@@ -50,18 +50,18 @@ export const isString = (value: any): value is string => typeof value === "strin
  * @returns {boolean} `true` if the value is a number, `false` otherwise.
  * (Note: `NaN` is also considered a number)
  */
-export const isNumber = (value: any): value is number => typeof value === "number";
+export const isNumber = (value: unknown): value is number => typeof value === "number";
 
 /**
  * Checks if a value is a plain object type (not null, array, or function)
  * @param value The value to check
  * @returns {boolean} `true` if the value is a plain object, `false` otherwise
  */
-export const isObject = (value: any): value is object => !isNullish(value) && typeof value === "object" && !isArray(value);
+export const isObject = (value: unknown): value is object => !isNullish(value) && typeof value === "object" && !isArray(value);
 
 /**
  * Check if the value is an array value
  * @param value The value to check
  * @returns {boolean} true if the value passed is an rray
  */
-export const isArray = (value: any): value is any[] => Array.isArray(value);
+export const isArray = (value: unknown): value is unknown[] => Array.isArray(value);


### PR DESCRIPTION
## Description
This pull request cleans up the utility types by replacing any with unknown in their definitions. These changes enhance type safety and improve the overall type checking in the codebase. The improvements include:

- Enhancing type safety offered by TypeScript
- Refining type definitions
- Reducing type checker errors

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->