### PR TITLE
feat: add ExtractToObject utility type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -260,3 +260,11 @@ export type PartialByKeys<T extends object, K extends keyof T = keyof T> = Prett
 export type OmitByType<T extends object, U> = {
 	[Property in keyof T as T[Property] extends U ? never : Property]: T[Property];
 };
+
+/**
+ * Extracts the value of a key from an object and returns a new object with that value, 
+ * while keeping the other values unchanged.
+ */
+export type ExtractToObject<T extends object, U extends keyof T> = Prettify<{
+	[Property in keyof T as Property extends U ? never: Property]: T[Property]
+} & T[U]>

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expectTypeOf } from "vitest"
-import type { Capitalize, Uppercase, Lowercase, TrimLeft, TrimRight, Trim, Merge, Properties } from "../src/utility-types"
+import type { Capitalize, Uppercase, Lowercase, TrimLeft, TrimRight, Trim, Merge, Properties, ExtractToObject } from "../src/utility-types"
 
 
 describe("String mappers", () => {
@@ -61,5 +61,13 @@ describe("Merge values",  () => {
         expectTypeOf<Merge<{ a: number }, { b: string }>>().toEqualTypeOf<{ a: number, b: string }>()
         expectTypeOf<Merge<{ a: number }, { b: string, c: boolean }>>().toEqualTypeOf<{ a: number, b: string, c: boolean }>()
         expectTypeOf<Merge<{ a: number }, { a: string, b: string }>>().toEqualTypeOf<{ a: string, b: string }>()
+    })
+})
+
+
+describe("Extract property from object", () => {
+    test("Extract the key", () => {
+        expectTypeOf<ExtractToObject<{ name: string, address: { street: string } }, "address">>().toEqualTypeOf<{ name: string, street: string }>()
+        expectTypeOf<ExtractToObject<{ name: string, address: { street: string, avenue: string } }, "address">>().toEqualTypeOf<{ name: string, street: string, avenue: string }>()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that extracts the value of a specific property from an object. In simple terms, it flattens the object by isolating the value of the specified key while preserving the rest of the object's properties.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->