### PR TITLE
feat: add `PublicType` utility type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -268,3 +268,10 @@ export type OmitByType<T extends object, U> = {
 export type ExtractToObject<T extends object, U extends keyof T> = Prettify<{
 	[Property in keyof T as Property extends U ? never: Property]: T[Property]
 } & T[U]>
+
+/**
+ * Removes the properties whose keys start with an underscore (_).
+ */
+export type PublicType<T extends object> = {
+	[Property in keyof T as Property extends `_${string}` ? never : Property]: T[Property];
+};

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expectTypeOf } from "vitest"
-import type { Capitalize, Uppercase, Lowercase, TrimLeft, TrimRight, Trim, Merge, Properties, ExtractToObject } from "../src/utility-types"
+import type { Capitalize, Uppercase, Lowercase, TrimLeft, TrimRight, Trim, Merge, Properties, ExtractToObject, PublicType } from "../src/utility-types"
 
 
 describe("String mappers", () => {
@@ -69,5 +69,14 @@ describe("Extract property from object", () => {
     test("Extract the key", () => {
         expectTypeOf<ExtractToObject<{ name: string, address: { street: string } }, "address">>().toEqualTypeOf<{ name: string, street: string }>()
         expectTypeOf<ExtractToObject<{ name: string, address: { street: string, avenue: string } }, "address">>().toEqualTypeOf<{ name: string, street: string, avenue: string }>()
+    })
+})
+
+
+describe("PublicType", () => {
+    test("Remove properties beginning with (_)", () => {
+        expectTypeOf<PublicType<{ foo: string }>>().toEqualTypeOf<{ foo: string }>();
+        expectTypeOf<PublicType<{ foo: string, _bar: string }>>().toEqualTypeOf<{ foo: string }>();
+        expectTypeOf<PublicType<{ _foo: string, _bar: string }>>().toEqualTypeOf<{}>();
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that allows for the removal of properties within an object whose keys begin with an underscore `_`, often referred to as `public properties.`


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->