### PR TITLE
feat: add `HasKeyObjects` utility type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -275,3 +275,13 @@ export type ExtractToObject<T extends object, U extends keyof T> = Prettify<{
 export type PublicType<T extends object> = {
 	[Property in keyof T as Property extends `_${string}` ? never : Property]: T[Property];
 };
+
+/**
+ * Checks if a key exists in either of the two objects and returns its value.
+ * If the key does not exist in either object, it returns `never`.
+ */
+export type HasKeyObjects<O1 extends object, O2 extends object, Key> = Key extends keyof O1
+        ? O1[Key]
+        : Key extends keyof O2
+                ? O2[Key]
+                : never;

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -1,5 +1,17 @@
 import { describe, test, expectTypeOf } from "vitest"
-import type { Capitalize, Uppercase, Lowercase, TrimLeft, TrimRight, Trim, Merge, Properties, ExtractToObject, PublicType } from "../src/utility-types"
+import type { 
+    Capitalize, 
+    Uppercase, 
+    Lowercase, 
+    TrimLeft, 
+    TrimRight, 
+    Trim, 
+    Merge, 
+    Properties, 
+    ExtractToObject, 
+    PublicType,
+    HasKeyObjects
+} from "../src/utility-types"
 
 
 describe("String mappers", () => {
@@ -78,5 +90,14 @@ describe("PublicType", () => {
         expectTypeOf<PublicType<{ foo: string }>>().toEqualTypeOf<{ foo: string }>();
         expectTypeOf<PublicType<{ foo: string, _bar: string }>>().toEqualTypeOf<{ foo: string }>();
         expectTypeOf<PublicType<{ _foo: string, _bar: string }>>().toEqualTypeOf<{}>();
+    })
+})
+
+describe("HasKeyObjects", () => {
+    test("Exist the key within objects", () => {
+        expectTypeOf<HasKeyObjects<{ foo: string }, { bar: number }, "foo">>().toEqualTypeOf<string>()
+        expectTypeOf<HasKeyObjects<{ foo: string }, { bar: number }, "bar">>().toEqualTypeOf<number>()
+        expectTypeOf<HasKeyObjects<{ foo: string }, { foo: number }, "foo">>().toEqualTypeOf<string>()
+        expectTypeOf<HasKeyObjects<{ foo: string }, { foo: number }, "foobar">>().toEqualTypeOf<never>()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that retrieves the value of a specified property from either of two objects. If the property does not exist in either object, it returns `never`.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->