### PR TITLE
refactor: clean up codebase with HasKeyObjects

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -183,11 +183,7 @@ export type Properties<T1 extends object, T2 extends object> = keyof T1 | keyof 
  * from `F` if they have the same key
  */
 export type Merge<T1 extends object, T2 extends object> = {
-	[Property in Properties<T1, T2>]: Property extends keyof T2
-		? T2[Property]
-		: Property extends keyof T1
-			? T1[Property]
-			: never;
+	[Property in Properties<T1, T2>]: HasKeyObjects<T2, T1, Property>
 };
 
 /**
@@ -211,11 +207,7 @@ export type Diff<O1 extends object, O2 extends object> = {
 		P extends keyof O1 & keyof O2 
 			? never
 			: P
-	]: P extends keyof O1 
-		? O1[P]
-		: P extends keyof O2
-			? O2[P]
-			: never;
+	]: HasKeyObjects<O1, O2, P>;
 };
 
 /**


### PR DESCRIPTION
## Description
This pull request cleans up the codebase by introducing the `HasKeyObjects` utility type, which retrieves the value of a specified key from either of two objects. If the key does not exist in either object, it returns never.

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->