### PR TITLE
refactor: move utils-types to string-mappers file

### DIFF
--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -1,0 +1,65 @@
+import type { LetterToLowercase, LetterToUppercase, WhiteSpaces } from "./types";
+
+/**
+ * Removes leading whitespace characters from a string type
+ * @example
+ * type Str = "  hello world  ";
+ * type TrimmedLeft = TrimLeft<Str>; // TrimmedLeft = "hello world  "
+ */
+export type TrimLeft<S extends string> = S extends `${WhiteSpaces}${infer Characters}`
+	? TrimLeft<Characters>
+	: S;
+
+/**
+ * Removes trailing whitespace characters from a string type
+ * @example
+ * type Str = "hello world  ";
+ * type TrimmedRight = TrimRight<Str>; // TrimmedRight = "hello world"
+ */
+export type TrimRight<S extends string> = S extends `${infer Char}${WhiteSpaces}`
+	? TrimRight<Char>
+	: S;
+
+
+/**
+ * Removes leading and trailing whitespace characters from a string type
+ * @example
+ * type Str = "  hello world  ";
+ * type Trimmed = Trim<Str>; // Trimmed = "hello world"
+ */
+export type Trim<S extends string> = S extends `${WhiteSpaces}${infer Characters}`
+	? Trim<Characters>
+	: S extends `${infer Char}${WhiteSpaces}`
+		? Trim<Char>
+		: S;
+
+/**
+ *  Converts a string to uppercase
+ */
+export type Uppercase<S extends string> = S extends `${infer Char}${infer Characters}` 
+	? Char extends keyof LetterToUppercase 
+		? `${LetterToUppercase[Char]}${Uppercase<Characters>}`
+		: `${Char}${Uppercase<Characters>}`
+	: S;
+
+/**
+ * Converts a string to lowercase
+ */
+export type Lowercase<S extends string> = S extends `${infer Char}${infer Characters}` 
+	? Char extends keyof LetterToLowercase
+		? `${LetterToLowercase[Char]}${Lowercase<Characters>}`
+		: `${Char}${Lowercase<Characters>}`
+	: S;
+
+/**
+ * Capitalizes the first letter of a word and converts the rest to lowercase
+ */
+export type Capitalize<S extends string, F extends boolean = true> = S extends `${infer Char}${infer Characters}`
+	? F extends boolean
+		? F extends true
+			? `${Uppercase<Char>}${Capitalize<Characters, false>}`
+			: Char extends " "
+				? ` ${Capitalize<Characters, true>}`
+				: `${Lowercase<Char>}${Capitalize<Characters, false>}`
+		: S
+	: S;

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,5 +1,5 @@
 import type { Equals } from "./test";
-import type { ArgsFunction, LetterToLowercase, LetterToUppercase, WhiteSpaces } from "./types";
+import type { ArgsFunction } from "./types";
 
 /**
  * Utility type that transforms an object to have each property on a new line
@@ -111,67 +111,6 @@ export type Omit<T extends object, U> = {
 	[Property in keyof T as Property extends U ? never : Property]: T[Property]
 };
 
-/**
- * Removes leading whitespace characters from a string type
- * @example
- * type Str = "  hello world  ";
- * type TrimmedLeft = TrimLeft<Str>; // TrimmedLeft = "hello world  "
- */
-export type TrimLeft<S extends string> = S extends `${WhiteSpaces}${infer Characters}`
-	? TrimLeft<Characters>
-	: S
-/**
- * Removes trailing whitespace characters from a string type
- * @example
- * type Str = "hello world  ";
- * type TrimmedRight = TrimRight<Str>; // TrimmedRight = "hello world"
- */
-export type TrimRight<S extends string> = S extends `${infer Char}${WhiteSpaces}`
-	? TrimRight<Char>
-	: S;
-
-/**
- * Removes leading and trailing whitespace characters from a string type
- * @example
- * type Str = "  hello world  ";
- * type Trimmed = Trim<Str>; // Trimmed = "hello world"
- */
-export type Trim<S extends string> = S extends `${WhiteSpaces}${infer Characters}`
-	? Trim<Characters>
-	: S extends `${infer Char}${WhiteSpaces}`
-		? Trim<Char>
-		: S;
-
-/**
- *  Converts a string to uppercase
- */
-export type Uppercase<S extends string> = S extends `${infer Char}${infer Characters}` 
-	? Char extends keyof LetterToUppercase 
-		? `${LetterToUppercase[Char]}${Uppercase<Characters>}`
-		: `${Char}${Uppercase<Characters>}`
-	: S;
-
-/**
- * Converts a string to lowercase
- */
-export type Lowercase<S extends string> = S extends `${infer Char}${infer Characters}` 
-	? Char extends keyof LetterToLowercase 
-		? `${LetterToLowercase[Char]}${Lowercase<Characters>}`
-		: `${Char}${Lowercase<Characters>}`
-	: S;
-
-/**
- * Capitalizes the first letter of a word and converts the rest to lowercase
- */
-export type Capitalize<S extends string, F extends boolean = true> = S extends `${infer Char}${infer Characters}`
-	? F extends boolean
-		? F extends true
-			? `${Uppercase<Char>}${Capitalize<Characters, false>}`
-			: Char extends " "
-				? ` ${Capitalize<Characters, true>}`
-				: `${Lowercase<Char>}${Capitalize<Characters, false>}`
-		: S
-	: S;
 
 /**
  * Creates a union of the keys of two objects


### PR DESCRIPTION
## Description
This pull request moves the string utility types to their own file, `string-mappers`, dedicated to string manipulation utilities. This change improves the structure and readability of the code


## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->