### PR TITLE
refactor: add imports for string-mappers in index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,12 +11,6 @@ export type {
     Parameters, 
     Pick,
     Omit,
-    Trim,
-    TrimLeft,
-    TrimRight,
-    Lowercase,
-    Uppercase,
-    Capitalize,
     Diff,
     Merge,
     PartialByKeys,
@@ -53,3 +47,12 @@ export type {
 export type {
     IsNever
 } from "./type-guards"
+
+export type {
+    Trim,
+    TrimLeft,
+    TrimRight,
+    Lowercase,
+    Uppercase,
+    Capitalize
+} from "./string-mappers"


### PR DESCRIPTION
## Description
This pull request updates index.ts to include imports from the `string-mappers.ts` file. This change ensures that the utility types from string-mappers are properly exported and accessible throughout the package.


## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->