### PR TITLE
feat: add `RequiredByKeys` utility type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -258,3 +258,20 @@ export type HasKeyObjects<O1 extends object, O2 extends object, Key> = Key exten
         : Key extends keyof O2
                 ? O2[Key]
                 : never;
+
+/**
+ * Convert to required the keys speficied in the type `K`, and the others fields mantein
+ * their definition. When `K` is not provided, it should make all properties required 
+ * 
+ * @example
+ * interface User {
+ *   name?: string,
+ *   age?: number,
+ *   address?: string
+ * }
+ * type UserRequiredName = RequiredByKeys<User, "name"> // { name: string, age?: number, address?: string }
+ */
+export type RequiredByKeys<T extends object, K extends keyof T = keyof T> = Prettify<
+	{ [Property in keyof T as Property extends K ? never : Property]: T[Property] } & 
+	{ [Property in keyof T as Property extends K ? Property : never]-?: T[Property] }
+>;				

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -6,7 +6,8 @@ import type {
     PublicType,
     HasKeyObjects,
     DeepReadonly,
-    TupleToUnion
+    TupleToUnion,
+    RequiredByKeys
 } from "../src/utility-types"
 
 
@@ -62,11 +63,21 @@ describe("PublicType", () => {
     })
 })
 
+
 describe("HasKeyObjects", () => {
     test("Exist the key within objects", () => {
         expectTypeOf<HasKeyObjects<{ foo: string }, { bar: number }, "foo">>().toEqualTypeOf<string>()
         expectTypeOf<HasKeyObjects<{ foo: string }, { bar: number }, "bar">>().toEqualTypeOf<number>()
         expectTypeOf<HasKeyObjects<{ foo: string }, { foo: number }, "foo">>().toEqualTypeOf<string>()
         expectTypeOf<HasKeyObjects<{ foo: string }, { foo: number }, "foobar">>().toEqualTypeOf<never>()
+    })
+})
+
+
+describe("RequiredByKeys", () => {
+    test("Convert required properties in an object", () => {
+        expectTypeOf<RequiredByKeys<{ foo?: string, bar?: number }, "foo">>().toEqualTypeOf<{ foo: string, bar?: number }>()
+        expectTypeOf<RequiredByKeys<{ foo?: string, bar?: number }, "bar">>().toEqualTypeOf<{ foo?: string, bar: number }>()
+        expectTypeOf<RequiredByKeys<{ foo?: string, bar?: number }>>().toEqualTypeOf<{ foo: string, bar: number }>()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that converts a set of properties to required in an object. If the properties of type K are not provided, all properties will be made required.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->