### PR TITLE
feat: add `Mutable` utility type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -311,3 +311,21 @@ export type MergeKeyObjects<O1 extends object, O2 extends object> = {
 			? O2[Prop]
 			: never;
 };
+
+/**
+ * Converts top-level readonly properties of an object to mutable properties.
+ *
+ * **Important:** Only affects top-level properties, not nested properties.
+ *
+ * @example
+ * interface User {
+ *   readonly name: string;
+ *   readonly lastname: string;
+ *   readonly age: number;
+ * }
+ *
+ * type NonReadonlyUser = Mutable<User>; // { name: string, lastname: string, age: number }
+ */
+export type Mutable<T extends object> = {
+	-readonly[Property in keyof T]: T[Property]
+}

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -9,7 +9,8 @@ import type {
     TupleToUnion,
     RequiredByKeys,
     Filter,
-    MergeKeyObjects
+    MergeKeyObjects,
+    Mutable
 } from "../src/utility-types"
 
 
@@ -100,5 +101,13 @@ describe("MergeKeyObjects", () => {
         expectTypeOf<MergeKeyObjects<{ foo: string }, { bar: string }>>().toEqualTypeOf<{ foo: string, bar: string }>()
         expectTypeOf<MergeKeyObjects<{ foo: string }, { foo: number }>>().toEqualTypeOf<{ foo: string | number }>()
         expectTypeOf<MergeKeyObjects<{ foo: string | number }, { foo: boolean }>>().toEqualTypeOf<{ foo: string | number | boolean }>()
+    })
+})
+
+
+describe("Mutable", () => {
+    test("Converts properties to non readonly only one level", () => {
+        expectTypeOf<Mutable<{ readonly foo: string }>>().toEqualTypeOf<{ foo: string }>()
+        expectTypeOf<Mutable<{ readonly foo: string, readonly bar: { readonly foobar: number } }>>().toEqualTypeOf<{ foo: string, bar: { readonly foobar: number } }>()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that transforms the top-level properties of an object to non-readonly properties. This can be useful when you want to update the properties in the future while ensuring that the values of these properties remain immutable.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->