### PR TITLE
feat: add `AppendToObject` utility type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -397,3 +397,16 @@ export type ToUnion<T> = T extends [infer Item, ...infer Items] ? Item | ToUnion
 export type Without<T extends readonly unknown[], Predicate, Array extends unknown[] = []> = T extends [infer Item, ...infer Items]
 		? Without<Items, Predicate, Item extends ToUnion<Predicate> ? Array : [...Array, Item]>
 		: Array;
+
+/**
+ * Create a new object type appending a new property with its value
+ * 
+ * @example
+ * interface User {
+ *   name: string
+ * }
+ * type UserAppendLastname = AppendToObject<User, "lastname", string>
+ */
+export type AppendToObject<T extends object, U extends string, V> = {
+	[Property in keyof T | U]: Property extends keyof T ? T[Property] : V
+}

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -14,7 +14,8 @@ import type {
     DeepMutable,
     MergeAll,
     ToUnion,
-    Without
+    Without,
+    AppendToObject    
 } from "../src/utility-types"
 
 
@@ -183,5 +184,15 @@ describe("Without", () => {
         expectTypeOf<Without<["foo", "bar", "foobar", 1, 2], "foo" | 2>>().toEqualTypeOf<["bar", "foobar", 1]>
         expectTypeOf<Without<[{ foo: string }, { bar: number }, { foobar: boolean }], { bar: number }>>().toEqualTypeOf<[{ foo: string }, { foobar: boolean }]>
         expectTypeOf<Without<["foo", "bar", "foobar", 1, 2, { foo: string }], { foo: string }>>().toEqualTypeOf<["foo", "bar", "foobar", 1, 2]>
+    })
+})
+
+
+describe("AppendToObject", () => {
+    test("Append a new property of an exist object type", () => {
+        expectTypeOf<AppendToObject<{ foo: string }, "bar", number>>().toEqualTypeOf<{ foo: string, bar: number }>()
+        expectTypeOf<AppendToObject<{ foo: string }, "bar", { foobar: number, barfoo: boolean }>>().toEqualTypeOf<{ foo: string, bar: { foobar: number, barfoo: boolean } }>()
+        expectTypeOf<AppendToObject<{ foo: string }, "bar", [1, 2, 3]>>().toEqualTypeOf<{ foo: string, bar: [1, 2, 3] }>()
+        expectTypeOf<AppendToObject<{ foo: string }, "bar", string | boolean | number>>().toEqualTypeOf<{ foo: string, bar: string | boolean | number }>()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that allows appending a new property and its value to any object type, creating a new object type with the added property. This is useful when you want to add a new property based on another type without significantly altering the existing structure of the object type.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->