### PR TITLE
feat: add `PercentageParser` utility type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -471,3 +471,26 @@ export type LastIndexOf<T extends unknown[], U, Index extends unknown[] = [], In
 		: IndexOf extends [...any, infer Item]
 			? Item
 			: -1;
+
+/**
+ * Parses a percentage string into a tuple of [Sign, Number, Unit].
+ * - `Sign` can be "+" or "-" or an empty string if no sign is present.
+ * - `Number` is the numerical part of the percentage.
+ * - `Unit` is the percentage symbol "%" or an empty string if no unit is present.
+ * 
+ * @example
+ * type Test1 = PercentageParser<"-12"> // ["-", "12", ""]
+ * type Test2 = PercentageParser<"+89%"> // ["+", "89", "%"]
+ */
+export type PercentageParser<Percentage extends string, Sign extends string = "", Num extends string = "", Unit extends string = ""> =
+	Percentage extends `${infer Char}${infer Chars}`
+	? Char extends "+" | "-"
+		? PercentageParser<Chars, Char, Num, Unit>
+		: Char extends "%"
+			? PercentageParser<Chars, Sign, Num, "%">
+			: Char extends `${number}` 
+				? PercentageParser<Chars, Sign, `${Num}${Char}`, Unit>
+				: Char extends "." | ","
+					? PercentageParser<Char, Sign, `${Num}${Char}`, Unit>
+					: never
+	: [Sign, Num, Unit];

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -23,7 +23,8 @@ import type {
     Diff,
     Pop,
     Last,
-    Size
+    Size,
+    PercentageParser
 } from "../src/utility-types"
 
 
@@ -266,5 +267,15 @@ describe("Tuple methods", () => {
             expectTypeOf<LastIndexOf<[string, 2, number, 'a', number, 1], number>>().toEqualTypeOf<4>()
             expectTypeOf<LastIndexOf<[string, any, 1, number, 'a', any, 1], any>>().toEqualTypeOf<5>()
         })
+    })
+})
+
+
+describe("PercentageParser", () => {
+    test("Parses a percentage string into a tuple", () => {
+        expectTypeOf<PercentageParser<"foobar">>().toEqualTypeOf<never>()
+        expectTypeOf<PercentageParser<"2024">>().toEqualTypeOf<["", "2024", ""]>()
+        expectTypeOf<PercentageParser<"-89">>().toEqualTypeOf<["-", "89", ""]>()
+        expectTypeOf<PercentageParser<"+89%">>().toEqualTypeOf<["+", "89", "%"]>()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that parses a percentage string into a tuple. The tuple splits the content into three components: Sign, Number, and Unit.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->