### PR TITLE
feat: add `ConstructTuple` utility type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -494,3 +494,20 @@ export type PercentageParser<Percentage extends string, Sign extends string = ""
 					? PercentageParser<Char, Sign, `${Num}${Char}`, Unit>
 					: never
 	: [Sign, Num, Unit];
+
+/**
+ * Helper type to create a tuple with a specific length, repeating a given value
+ * Avoids the `Type instantiation is excessively deep and possibly infinite` error
+ */
+type Extend<Length extends number, Value extends unknown = unknown, Array extends unknown[] = []> = Array["length"] extends Length
+	? Array
+	: Extend<Length, Value, [...Array, Value]>;
+
+/**
+ * reate a tuple with a defined size, where each element is of a specified type
+ * 
+ * @example
+ * type TupleSize2 = ConstructTuple<2> // [unknown, unknown]
+ * type TupleSize3 = ConstructTuple<2, ""> // ["", ""]
+ */
+export type ConstructTuple<Length extends number, Value extends unknown = unknown, Array extends unknown[] = []> = Extend<Length, Value, Array>;

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -499,9 +499,9 @@ export type PercentageParser<Percentage extends string, Sign extends string = ""
  * Helper type to create a tuple with a specific length, repeating a given value
  * Avoids the `Type instantiation is excessively deep and possibly infinite` error
  */
-type Extend<Length extends number, Value extends unknown = unknown, Array extends unknown[] = []> = Array["length"] extends Length
+type RepeatConstructTuple<Length extends number, Value extends unknown = unknown, Array extends unknown[] = []> = Array["length"] extends Length
 	? Array
-	: Extend<Length, Value, [...Array, Value]>;
+	: RepeatConstructTuple<Length, Value, [...Array, Value]>;
 
 /**
  * reate a tuple with a defined size, where each element is of a specified type
@@ -510,4 +510,4 @@ type Extend<Length extends number, Value extends unknown = unknown, Array extend
  * type TupleSize2 = ConstructTuple<2> // [unknown, unknown]
  * type TupleSize3 = ConstructTuple<2, ""> // ["", ""]
  */
-export type ConstructTuple<Length extends number, Value extends unknown = unknown, Array extends unknown[] = []> = Extend<Length, Value, Array>;
+export type ConstructTuple<Length extends number, Value extends unknown = unknown, Array extends unknown[] = []> = RepeatConstructTuple<Length, Value, Array>;

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -28,7 +28,8 @@ import type {
     Omit,
     OmitByType,
     Parameters,
-    Includes    
+    Includes,
+    ConstructTuple
 } from "../src/utility-types"
 
 
@@ -322,5 +323,14 @@ describe("Includes", () => {
         expectTypeOf<Includes<[string, 1, () => void, {}], string>>().toEqualTypeOf<true>()
         expectTypeOf<Includes<[string, number, () => void, {}], number>>().toEqualTypeOf<true>()
         expectTypeOf<Includes<[true, false, true], number>>().toEqualTypeOf<false>()
+    })
+})
+
+
+describe("ConstructTuple", () => {
+    test("Create a tuple with a defined size", () => {
+        expectTypeOf<ConstructTuple<2>>().toEqualTypeOf<[unknown, unknown]>()
+        expectTypeOf<ConstructTuple<2, string>>().toEqualTypeOf<[string, string]>()
+        expectTypeOf<ConstructTuple<5, any>>().toEqualTypeOf<[any, any, any, any, any]>()        
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that allows the creation of a tuple of size `Length`, filled with a value of type `Value` provided as a parameter to the utility type.



## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->