### PR TITLE
feat: add `StartsWith` utility type

### DIFF
--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -76,3 +76,13 @@ export type Join<T extends unknown[], Separator extends number | string, Str ext
 	T extends [infer Char, ...infer Chars]
 		? Join<Chars, Separator, `${Str}${Str extends "" ? "" : Separator}${Char & string}`>
 		: Str;
+
+/**
+ * Checks if a string type matchs start with a strig `U`
+ * 
+ * @example
+ * type Test1 = StartsWith<'abc', 'ac'> // false
+ * type Test2 = StartsWith<'abc', 'ab'> // true
+ * type Test3 = StartsWith<'abc', 'abcd'> // false
+ */
+export type StartsWith<T extends string, U extends string> = T extends `${U}${string}` ? true : false;

--- a/testing/string-mappers.test.ts
+++ b/testing/string-mappers.test.ts
@@ -6,7 +6,8 @@ import type {
     TrimLeft,
     TrimRight,
     Trim,
-    Join
+    Join,
+    StartsWith
 } from "../src/string-mappers"
 
 
@@ -60,4 +61,16 @@ describe("Join", () => {
     expectTypeOf<Join<["a", "p", "p", "l", "e"], "-">>().toEqualTypeOf<"a-p-p-l-e">()
     expectTypeOf<Join<["Hello", "World"], " ">>().toEqualTypeOf<"Hello World">()
     expectTypeOf<Join<["2", "2", "2"], "1">>().toEqualTypeOf<"21212">()
+})
+
+
+describe("Match strings", () => {
+    test("StartsWith", () => {
+        expectTypeOf<StartsWith<"foobar", "foo">>().toEqualTypeOf<true>()
+        expectTypeOf<StartsWith<"foobar", "bar">>().toEqualTypeOf<false>()
+        expectTypeOf<StartsWith<"foobar", "obar">>().toEqualTypeOf<false>()
+        expectTypeOf<StartsWith<"foobar", "foobarr">>().toEqualTypeOf<false>()
+        expectTypeOf<StartsWith<"foobar", "">>().toEqualTypeOf<true>()
+        expectTypeOf<StartsWith<"", "">>().toEqualTypeOf<true>()
+    })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that allows us to check if a string matches the start of another string. This can be useful for verifying if a string type matches an initial substring.




## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->