### PR TITLE
feat: add `EndsWith` utility type

### DIFF
--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -97,3 +97,12 @@ export type StartsWith<T extends string, U extends string> = T extends `${U}${st
 export type DropChar<Str extends string, Match extends string, Build extends string = ""> = Str extends `${infer Char}${infer Chars}`
 	? DropChar<Chars, Match, Char extends Match ? Build : `${Build}${Char}`>
 	: Build;
+
+/**
+ * Checks if a string type matchs start with a strig `U`
+ * 
+ * @example
+ * type Test1 = EndsWith<'abc', 'bc'> // true
+ * type Test2 = EndsWith<'abc', 'ac'> // false
+ */
+export type EndsWith<T extends string, U extends string> = T extends `${string}${U}` ? true : false;

--- a/testing/string-mappers.test.ts
+++ b/testing/string-mappers.test.ts
@@ -1,4 +1,5 @@
 import { describe, test, expectTypeOf } from "vitest"
+
 import type {
     Capitalize,
     Uppercase,
@@ -8,7 +9,8 @@ import type {
     Trim,
     Join,
     StartsWith,
-    DropChar
+    DropChar,
+    EndsWith
 } from "../src/string-mappers"
 
 
@@ -73,6 +75,16 @@ describe("Match strings", () => {
         expectTypeOf<StartsWith<"foobar", "foobarr">>().toEqualTypeOf<false>()
         expectTypeOf<StartsWith<"foobar", "">>().toEqualTypeOf<true>()
         expectTypeOf<StartsWith<"", "">>().toEqualTypeOf<true>()
+    })
+
+
+    test("EndsWith", () => {
+        expectTypeOf<EndsWith<"foobar", "foo">>().toEqualTypeOf<false>()
+        expectTypeOf<EndsWith<"foobar", "bar">>().toEqualTypeOf<true>()
+        expectTypeOf<EndsWith<"bar", "br">>().toEqualTypeOf<false>()
+        expectTypeOf<EndsWith<"foobar", " ">>().toEqualTypeOf<false>()
+        expectTypeOf<EndsWith<"foobar", "">>().toEqualTypeOf<true>()
+        expectTypeOf<EndsWith<"", "">>().toEqualTypeOf<true>()
     })
 })
 


### PR DESCRIPTION
## Description
This pull request introduces a new string-mapper utility type that checks if a string type matches a given substring. This can be useful for verifying if a string type matches a specific ending substring.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->