### PR TITLE
feat: add `LengthOfString` utility type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -81,5 +81,6 @@ export type {
     Join,
     DropChar,
     StartsWith,
-    EndsWith
+    EndsWith,
+    LengthOfString
 } from "./string-mappers"

--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -106,3 +106,14 @@ export type DropChar<Str extends string, Match extends string, Build extends str
  * type Test2 = EndsWith<'abc', 'ac'> // false
  */
 export type EndsWith<T extends string, U extends string> = T extends `${string}${U}` ? true : false;
+
+/**
+ * Returns the length of a string type
+ * 
+ * @example
+ * type Length2 = LengthOfString<"foo"> // 3
+ * type Length6 = LengthOfString<"foobar"> // 6
+ */
+export type LengthOfString<Str extends string, Length extends unknown[] = []> = Str extends `${infer Char}${infer Chars}`
+	? LengthOfString<Chars, [...Length, Char]>
+	: Length["length"];

--- a/testing/string-mappers.test.ts
+++ b/testing/string-mappers.test.ts
@@ -10,7 +10,8 @@ import type {
     Join,
     StartsWith,
     DropChar,
-    EndsWith
+    EndsWith,
+    LengthOfString
 } from "../src/string-mappers"
 
 
@@ -94,5 +95,15 @@ describe("DropChar", () => {
         expectTypeOf<DropChar<"foobar foo!", " ">>().toEqualTypeOf<"foobarfoo!">()
         expectTypeOf<DropChar<"f o o b a r f o o !", " ">>().toEqualTypeOf<"foobarfoo!">()
         expectTypeOf<DropChar<"f o o b a r f o o !", any>>().toEqualTypeOf<"">()
+    })
+})
+
+
+describe("LengthOfString", () => {
+    test("Returns the length of a string type", () => {
+        expectTypeOf<LengthOfString<"">>().toEqualTypeOf<0>()
+        expectTypeOf<LengthOfString<any>>().toEqualTypeOf<0>()
+        expectTypeOf<LengthOfString<never>>().toEqualTypeOf<never>()
+        expectTypeOf<LengthOfString<"foobarfoobar">>().toEqualTypeOf<12>()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new string-mapper utility type that returns the length of a string type.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->