### PR TITLE
feat: add `Absolute` utility type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,8 @@ export type {
     LastIndexOf,
     PercentageParser,
     ConstructTuple,
-    CheckRepeatedTuple
+    CheckRepeatedTuple,
+    Absolute
 } from "./utility-types"
 
 export type { 

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,3 +1,4 @@
+import type { DropChar } from "./string-mappers";
 import type { Equals } from "./test";
 import type { ArgsFunction } from "./types";
 
@@ -524,3 +525,8 @@ export type CheckRepeatedTuple<T extends unknown[], Array extends unknown = ""> 
 		? true
 		: CheckRepeatedTuple<Items, Array | Item>
 	: false;
+
+/**
+ * Returns the absolute version of a number, string or bigint as a string
+ */
+export type Absolute<T extends number | string | bigint> = DropChar<`${T}`, "-" | "n">;

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -30,7 +30,8 @@ import type {
     Parameters,
     Includes,
     ConstructTuple,
-    CheckRepeatedTuple    
+    CheckRepeatedTuple,
+    Absolute
 } from "../src/utility-types"
 
 
@@ -344,5 +345,15 @@ describe("CheckRepeatedTuple", () => {
         expectTypeOf<CheckRepeatedTuple<["foo", "bar", 1, 5]>>().toEqualTypeOf<false>()
         expectTypeOf<CheckRepeatedTuple<[() => void, () => void]>>().toEqualTypeOf<true>()
         expectTypeOf<CheckRepeatedTuple<[{ foo: string }, { foo: string }]>>().toEqualTypeOf<true>()
+    })
+})
+
+
+describe("Absolute", () => {
+    test("Returns the absolute version of a number", () => {
+        expectTypeOf<Absolute<-100>>().toEqualTypeOf<"100">()
+        expectTypeOf<Absolute<-0>>().toEqualTypeOf<"0">()
+        expectTypeOf<Absolute<-999_999_999_999>>().toEqualTypeOf<"999999999999">()
+        expectTypeOf<Absolute<-999_999_999_999_999n>>().toEqualTypeOf<"999999999999999">()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that allows us to get the absolute value of a number, string, or bigint type and returns it as a string.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->