### PR TITLE
feat: add ObjectEntries utility type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,8 @@ export type {
     PercentageParser,
     ConstructTuple,
     CheckRepeatedTuple,
-    Absolute
+    Absolute,
+    ObjectEntries
 } from "./utility-types"
 
 export type { 

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -530,3 +530,19 @@ export type CheckRepeatedTuple<T extends unknown[], Array extends unknown = ""> 
  * Returns the absolute version of a number, string or bigint as a string
  */
 export type Absolute<T extends number | string | bigint> = DropChar<`${T}`, "-" | "n">;
+
+/**
+ * Returns a union type of the entries of the provided object
+ * 
+ * @example
+ * interface Foo {
+ *   foo: string,
+ *   bar: number,
+ *   foobar?: boolean
+ * }
+ * 
+ * type FooEntries = ObjectEntries<Foo> // ["foo", string] | ["bar", number] | ["foobar", boolean]
+ */
+export type ObjectEntries<Obj extends object, RequiredObj extends object = Required<Obj>> = {
+	[Property in keyof RequiredObj]: [Property, RequiredObj[Property] extends undefined ? undefined : RequiredObj[Property]];
+}[keyof RequiredObj];

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -365,5 +365,6 @@ describe("ObjectEntries", () => {
         expectTypeOf<ObjectEntries<{ foo: string }>>().toEqualTypeOf<["foo", string]>()
         expectTypeOf<ObjectEntries<{ foo?: string }>>().toEqualTypeOf<["foo", string]>()
         expectTypeOf<ObjectEntries<{ foo?: string, bar?: number }>>().toEqualTypeOf<["foo", string] | [ "bar", number]>()
+        expectTypeOf<ObjectEntries<{ foo?: undefined, bar: undefined | string }>>().toEqualTypeOf<["foo", undefined] | ["bar", undefined | string]>()
     })
 })

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -31,7 +31,8 @@ import type {
     Includes,
     ConstructTuple,
     CheckRepeatedTuple,
-    Absolute
+    Absolute,
+    ObjectEntries
 } from "../src/utility-types"
 
 
@@ -355,5 +356,14 @@ describe("Absolute", () => {
         expectTypeOf<Absolute<-0>>().toEqualTypeOf<"0">()
         expectTypeOf<Absolute<-999_999_999_999>>().toEqualTypeOf<"999999999999">()
         expectTypeOf<Absolute<-999_999_999_999_999n>>().toEqualTypeOf<"999999999999999">()
+    })
+})
+
+
+describe("ObjectEntries", () => {
+    test("Returns the entries from an object", () => {
+        expectTypeOf<ObjectEntries<{ foo: string }>>().toEqualTypeOf<["foo", string]>()
+        expectTypeOf<ObjectEntries<{ foo?: string }>>().toEqualTypeOf<["foo", string]>()
+        expectTypeOf<ObjectEntries<{ foo?: string, bar?: number }>>().toEqualTypeOf<["foo", string] | [ "bar", number]>()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that returns a tuple of the entries of an object. Specifically, it returns a union type of tuples containing the key and value pairs of the object.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->