### PR TITLE
feat: add `AllEquals` utility type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,7 +36,8 @@ export type {
     ConstructTuple,
     CheckRepeatedTuple,
     Absolute,
-    ObjectEntries
+    ObjectEntries,
+    AllEquals
 } from "./utility-types"
 
 export type { 

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -546,3 +546,16 @@ export type Absolute<T extends number | string | bigint> = DropChar<`${T}`, "-" 
 export type ObjectEntries<Obj extends object, RequiredObj extends object = Required<Obj>> = {
 	[Property in keyof RequiredObj]: [Property, RequiredObj[Property] extends undefined ? undefined : RequiredObj[Property]];
 }[keyof RequiredObj];
+
+/**
+ * Returns true if all elements within the tuple are equal to `Comparator` otherwise, returns false
+ * 
+ * @example
+ * type Test1 = AllEquals<[number, number, number], number> // true
+ * type Test2 = AllEquals<[[1], [1], [1]], [1]> // true
+ */
+export type AllEquals<T extends unknown[], Comparator> = T extends [infer Item, ...infer Items]
+	? Equals<Item, Comparator> extends true
+		? AllEquals<Items, Comparator>
+		: false
+	: true;

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -32,7 +32,8 @@ import type {
     ConstructTuple,
     CheckRepeatedTuple,
     Absolute,
-    ObjectEntries
+    ObjectEntries,
+    AllEquals
 } from "../src/utility-types"
 
 
@@ -366,5 +367,18 @@ describe("ObjectEntries", () => {
         expectTypeOf<ObjectEntries<{ foo?: string }>>().toEqualTypeOf<["foo", string]>()
         expectTypeOf<ObjectEntries<{ foo?: string, bar?: number }>>().toEqualTypeOf<["foo", string] | [ "bar", number]>()
         expectTypeOf<ObjectEntries<{ foo?: undefined, bar: undefined | string }>>().toEqualTypeOf<["foo", undefined] | ["bar", undefined | string]>()
+    })
+})
+
+
+describe("AllEquals", () => {
+    test("Check if all elements are equal", () => {
+        expectTypeOf<AllEquals<[0, 0, 0, 0], 1>>().toEqualTypeOf<false>()
+        expectTypeOf<AllEquals<[0, 0, 0, 0], 0>>().toEqualTypeOf<true>()
+        expectTypeOf<AllEquals<[0, 0, 1, 0], 1>>().toEqualTypeOf<false>()
+        expectTypeOf<AllEquals<[number, number, number, number], number>>().toEqualTypeOf<true>()
+        expectTypeOf<AllEquals<[[1], [1], [1]], [1]>>().toEqualTypeOf<true>()
+        expectTypeOf<AllEquals<[{}, {}, {}], {}>>().toEqualTypeOf<true>()
+        expectTypeOf<AllEquals<[1, 1, 2], 1 | 2>>().toEqualTypeOf<false>()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new utility type that allows us to check if all elements in a tuple are equal. This utility type can be useful for verifying the integrity of types within a tuple.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->