### PR TITLE
refactor: rename `Diff` utility type to `Intersection`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ export type {
     Parameters, 
     Pick,
     Omit,
-    Diff,
+    Intersection,
     Merge,
     PartialByKeys,
     PickByType,

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -187,19 +187,15 @@ export type Merge<T1 extends object, T2 extends object> = {
  * }
  * 
  * type Bar = {
- * 	ame: string
+ * 	name: string
  * 	age: string
  * 	gender: number
  * }
  * 
- * type DiffFoo = Diff<Foo, Bar> // { gender: number }
+ * type DiffFoo = Intersection<Foo, Bar> // { gender: number }
  */
-export type Diff<O1 extends object, O2 extends object> = {
-	[P in Properties<O1, O2> as 
-		P extends keyof O1 & keyof O2 
-			? never
-			: P
-	]: HasKeyObjects<O1, O2, P>;
+export type Intersection<O1 extends object, O2 extends object> = {
+	[P in Properties<O1, O2> as P extends keyof O1 & keyof O2 ? never : P]: HasKeyObjects<O1, O2, P>;
 };
 
 /**

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -20,7 +20,7 @@ import type {
     Reverse,
     IndexOf,
     LastIndexOf,
-    Diff,
+    Intersection,
     Pop,
     Last,
     Size,
@@ -199,9 +199,9 @@ describe("AppendToObject", () => {
 
 describe("Difference", () => {
     test("Difference of properties between two objects", () => {
-        expectTypeOf<Diff<{ foo: string }, { foo: number, bar: boolean }>>().toEqualTypeOf<{ bar: boolean }>()
-        expectTypeOf<Diff<{ foo: string, bar: boolean }, { bar: number, foo: bigint }>>().toEqualTypeOf<{}>()
-        expectTypeOf<Diff<{ foo: string, bar: { bar: number } }, { barfoo: { bar: number }, foo: bigint }>>().toEqualTypeOf<{ bar: { bar: number }, barfoo: { bar: number } }>()
+        expectTypeOf<Intersection<{ foo: string }, { foo: number, bar: boolean }>>().toEqualTypeOf<{ bar: boolean }>()
+        expectTypeOf<Intersection<{ foo: string, bar: boolean }, { bar: number, foo: bigint }>>().toEqualTypeOf<{}>()
+        expectTypeOf<Intersection<{ foo: string, bar: { bar: number } }, { barfoo: { bar: number }, foo: bigint }>>().toEqualTypeOf<{ bar: { bar: number }, barfoo: { bar: number } }>()
     })
 })
 


### PR DESCRIPTION
## Description
This pull request renames the `Diff` utility type to `Intersection` to enhance its description and readability. The new name better reflects the utility's purpose and functionality.


## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->