### PR TITLE
feat: add `IndexOfString` string-mapper

### DIFF
--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -1,3 +1,4 @@
+import type { Equals } from "./test";
 import type { LetterToLowercase, LetterToUppercase, WhiteSpaces } from "./types";
 
 /**
@@ -117,3 +118,17 @@ export type EndsWith<Str extends string, Match extends string> = Str extends `${
 export type LengthOfString<Str extends string, Length extends unknown[] = []> = Str extends `${infer Char}${infer Chars}`
 	? LengthOfString<Chars, [...Length, Char]>
 	: Length["length"];
+
+/**
+ * Returns the first index of the character that matches `Match`. 
+ * Otherwise, it returns -1.
+ * 
+ * @example
+ * type IndexOfA = IndexOfString<"comparator is a function", "i"> // 12
+ * type IndexOfOutBound = IndexOfString<"comparator is a function", "z"> // -1
+ */
+export type IndexOfString<Str extends string, Match extends string, Index extends unknown[] = []> = Str extends `${infer Char}${infer Chars}`
+	? Equals<Char, Match> extends true
+		? Index["length"]
+		: IndexOfString<Chars, Match, [...Index, 1]>
+	: -1;

--- a/testing/string-mappers.test.ts
+++ b/testing/string-mappers.test.ts
@@ -11,7 +11,8 @@ import type {
     StartsWith,
     DropChar,
     EndsWith,
-    LengthOfString
+    LengthOfString,
+    IndexOfString
 } from "../src/string-mappers"
 
 
@@ -61,7 +62,7 @@ describe("String mappers", () => {
 
 
 describe("Join", () => {
-    test("Join the elements of a tuple separated by a character", () => {})
+    test("Join the elements of a tuple separated by a character", () => { })
     expectTypeOf<Join<["a", "p", "p", "l", "e"], "-">>().toEqualTypeOf<"a-p-p-l-e">()
     expectTypeOf<Join<["Hello", "World"], " ">>().toEqualTypeOf<"Hello World">()
     expectTypeOf<Join<["2", "2", "2"], "1">>().toEqualTypeOf<"21212">()
@@ -105,5 +106,16 @@ describe("LengthOfString", () => {
         expectTypeOf<LengthOfString<any>>().toEqualTypeOf<0>()
         expectTypeOf<LengthOfString<never>>().toEqualTypeOf<never>()
         expectTypeOf<LengthOfString<"foobarfoobar">>().toEqualTypeOf<12>()
+    })
+})
+
+
+describe("IndexOfString", () => {
+    test("Returns the first index occurrence of a character", () => {
+        expectTypeOf<IndexOfString<"", never>>().toEqualTypeOf<-1>()
+        expectTypeOf<IndexOfString<"foobar", "f">>().toEqualTypeOf<0>()
+        expectTypeOf<IndexOfString<"foobar", "b">>().toEqualTypeOf<3>()
+        expectTypeOf<IndexOfString<"foobar", "r">>().toEqualTypeOf<5>()
+        expectTypeOf<IndexOfString<"foobar", "x">>().toEqualTypeOf<-1>()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new string-mapper utility that helps retrieve the index of the first occurrence of a specified character within a string. If the character matches the comparator value, the index of the first occurrence is returned. If the character does not appear in the string, the utility returns `-1` to indicate its absence.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->