### PR TITLE
feat: add `FirstUniqueCharIndex` string-mapper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,5 +85,7 @@ export type {
     DropChar,
     StartsWith,
     EndsWith,
-    LengthOfString
+    LengthOfString,
+    IndexOfString,
+    FirstUniqueCharIndex
 } from "./string-mappers"

--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -138,8 +138,8 @@ export type IndexOfString<Str extends string, Match extends string, Index extend
  * If all of the characters are repeated, it returns -1.
  * 
  * @example
- * type IndexOfC = FirstUniqueCharIndex<"aabcb"> // -1
- * type IndexOfOutBound = FirstUniqueCharIndex<"aabbcc"> // 1
+ * type IndexOfC = FirstUniqueCharIndex<"aabcb"> // 3
+ * type IndexOfOutBound = FirstUniqueCharIndex<"aabbcc"> // -1
  */
 export type FirstUniqueCharIndex<Str extends string, Index extends unknown[] = [], Build extends string = ""> = Str extends `${infer Char}${infer Chars}`
 	? IndexOfString<Chars, Char> extends -1

--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -132,3 +132,19 @@ export type IndexOfString<Str extends string, Match extends string, Index extend
 		? Index["length"]
 		: IndexOfString<Chars, Match, [...Index, 1]>
 	: -1;
+
+/**
+ * Returns the first index of a character that is unique within the given string.
+ * If all of the characters are repeated, it returns -1.
+ * 
+ * @example
+ * type IndexOfC = FirstUniqueCharIndex<"aabcb"> // -1
+ * type IndexOfOutBound = FirstUniqueCharIndex<"aabbcc"> // 1
+ */
+export type FirstUniqueCharIndex<Str extends string, Index extends unknown[] = [], Build extends string = ""> = Str extends `${infer Char}${infer Chars}`
+	? IndexOfString<Chars, Char> extends -1
+		? Char extends Build
+			? FirstUniqueCharIndex<Chars, [...Index, 1], Char | Build>
+			: Index["length"]
+		: FirstUniqueCharIndex<Chars, [...Index, 1], Char | Build>
+	: -1;

--- a/testing/string-mappers.test.ts
+++ b/testing/string-mappers.test.ts
@@ -12,7 +12,8 @@ import type {
     DropChar,
     EndsWith,
     LengthOfString,
-    IndexOfString
+    IndexOfString,
+    FirstUniqueCharIndex
 } from "../src/string-mappers"
 
 
@@ -117,5 +118,16 @@ describe("IndexOfString", () => {
         expectTypeOf<IndexOfString<"foobar", "b">>().toEqualTypeOf<3>()
         expectTypeOf<IndexOfString<"foobar", "r">>().toEqualTypeOf<5>()
         expectTypeOf<IndexOfString<"foobar", "x">>().toEqualTypeOf<-1>()
+    })
+})
+
+
+describe("FirstUniqueCharIndex", () => {
+    test("Returns the first index of a character that is not repeated", () => {
+        expectTypeOf<FirstUniqueCharIndex<"">>().toEqualTypeOf<-1>()
+        expectTypeOf<FirstUniqueCharIndex<"comparator">>().toEqualTypeOf<0>()
+        expectTypeOf<FirstUniqueCharIndex<"comparator and comparable">>().toEqualTypeOf<7>()
+        expectTypeOf<FirstUniqueCharIndex<"aabbcc">>().toEqualTypeOf<-1>()
+        expectTypeOf<FirstUniqueCharIndex<"aabcb">>().toEqualTypeOf<3>()
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new `string-mapper` utility that returns the index of the first character in a string that does not repeat. If no such character exists, the utility indicates that all characters are repeated.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->