### PR TITLE
feat: add `Replace` string-mapper

### DIFF
--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -155,3 +155,16 @@ export type FirstUniqueCharIndex<
             : Index["length"]
         : FirstUniqueCharIndex<Chars, [...Index, 1], Char | Build>
     : -1;
+
+/**
+ * Replaces the first match of the substring `From` in the string `S` with the new value `To`
+ *
+ * @example
+ * type Replace1 = Replace<'foobar', 'bar', 'foo'> // 'foofoo'
+ * type Replace2 = Replace<'foobarbar', 'bar', 'foo'> // 'foofoobar'
+ */
+export type Replace<S extends string, From extends string, To extends string> = From extends ""
+    ? S
+    : S extends `${infer Head}${From}${infer Tail}`
+      ? `${Head}${To}${Tail}`
+      : S;

--- a/testing/string-mappers.test.ts
+++ b/testing/string-mappers.test.ts
@@ -14,6 +14,7 @@ import type {
     LengthOfString,
     IndexOfString,
     FirstUniqueCharIndex,
+    Replace,
 } from "../src/string-mappers";
 
 describe("String mappers", () => {
@@ -120,5 +121,14 @@ describe("FirstUniqueCharIndex", () => {
         expectTypeOf<FirstUniqueCharIndex<"comparator and comparable">>().toEqualTypeOf<7>();
         expectTypeOf<FirstUniqueCharIndex<"aabbcc">>().toEqualTypeOf<-1>();
         expectTypeOf<FirstUniqueCharIndex<"aabcb">>().toEqualTypeOf<3>();
+    });
+});
+
+describe("Replace", () => {
+    test("Replace the first match with a new value", () => {
+        expectTypeOf<Replace<"foobar", "bar", "foo">>().toEqualTypeOf<"foofoo">();
+        expectTypeOf<Replace<"foobarbar", "bar", "foo">>().toEqualTypeOf<"foofoobar">();
+        expectTypeOf<Replace<"foobarbar", "", "foo">>().toEqualTypeOf<"foobarbar">();
+        expectTypeOf<Replace<"foobarbar", "bar", "">>().toEqualTypeOf<"foobar">();
     });
 });


### PR DESCRIPTION
## Description
This pull request introduces a new `string-mapper` utility type called `Replace`. This utility works with strings to update a portion of the string based on a matching substring. If a match is found, it returns a new string with the specified value replacing the matched portion. If no match is found, it returns the original string unchanged.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->