### PR TITLE
chore: add `ReplaceKeys` utility type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export type {
     Absolute,
     ObjectEntries,
     AllEquals,
+    ReplaceKeys,
 } from "./utility-types";
 
 export type {
@@ -73,4 +74,5 @@ export type {
     LengthOfString,
     IndexOfString,
     FirstUniqueCharIndex,
+    Replace,
 } from "./string-mappers";

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -574,3 +574,24 @@ export type AllEquals<Array extends unknown[], Comparator> = Array extends [infe
         ? AllEquals<Spread, Comparator>
         : false
     : true;
+
+/**
+ * Replaces the types of the keys in an object with new types defined in the `Replace` object.
+ * If a key in `Keys` is not found in `Replace`, it defaults to the `Default` type.
+ *
+ * @example
+ * interface Foo {
+ *     foo: string,
+ *     bar: number,
+ *     foobar: boolean
+ * }
+ * //Expected: { foo: number, bar: number, foobar: number }
+ * type ReplaceStrings = ReplaceKeys<Foo, "foo" | "foobar", { foo: number, foobar: number }>
+ */
+export type ReplaceKeys<Obj extends object, Keys extends string, Replace extends object, Default = unknown> = {
+    [Property in keyof Obj]: Property extends Keys
+        ? Property extends keyof Replace
+            ? Replace[Property]
+            : Default
+        : Obj[Property];
+};

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -36,6 +36,7 @@ import type {
     AllEquals,
     Pick,
     PickByType,
+    ReplaceKeys,
 } from "../src/utility-types";
 
 describe("Readonly", () => {
@@ -443,5 +444,26 @@ describe("Pick Utilities", () => {
             expectTypeOf<PickByType<{ foo: () => {}; bar: number; foobar: {} }, never>>().toEqualTypeOf<{}>();
             expectTypeOf<PickByType<{ foo: () => {}; bar: number; foobar: {} }, () => {}>>().toEqualTypeOf<{ foo: () => {} }>();
         });
+    });
+});
+
+describe("ReplaceKeys", () => {
+    test("Replace the key types", () => {
+        expectTypeOf<ReplaceKeys<{ foo: string; bar: number }, "bar", { bar: string }>>().toEqualTypeOf<{
+            foo: string;
+            bar: string;
+        }>();
+        expectTypeOf<ReplaceKeys<{ foo: string; bar: number }, "foobar", { bar: string }>>().toEqualTypeOf<{
+            foo: string;
+            bar: number;
+        }>();
+        expectTypeOf<ReplaceKeys<{ foo: string; bar: number }, "bar", { foobar: string }>>().toEqualTypeOf<{
+            foo: string;
+            bar: unknown;
+        }>();
+        expectTypeOf<ReplaceKeys<{ foo: string; bar: number }, "foo" | "bar", { foo: number; bar: boolean }>>().toEqualTypeOf<{
+            foo: number;
+            bar: boolean;
+        }>();
     });
 });


### PR DESCRIPTION
## Description
This pull request introduces a new utility type called `ReplaceKeys`. This utility type allows for replacing the types of specific keys in an object with new types provided in the utility type.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->