### PR TITLE
feat: add `MapTypes` utility type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export type {
     ObjectEntries,
     AllEquals,
     ReplaceKeys,
+    MapTypes,
 } from "./utility-types";
 
 export type {

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -595,3 +595,24 @@ export type ReplaceKeys<Obj extends object, Keys extends string, Replace extends
             : Default
         : Obj[Property];
 };
+
+/**
+ * Transforms the types of the keys in an object that match the `from` type in the `Mapper`,
+ * replacing them with the `to` type in the `Mapper`.
+ *
+ * @example
+ * // Expected: { foo: string, bar: boolean }
+ * type ReplaceTypesI = MapTypes<{ foo: string, bar: number }, { from: number, to: boolean }>
+ *
+ * // Expected: { foo: number, bar: number  }
+ * type ReplaceTypesII = MapTypes<{ foo: string, bar: string }, { from: string, bar: number }>
+ */
+export type MapTypes<Obj extends object, Mapper extends { from: unknown; to: unknown }> = {
+    [Property in keyof Obj]: Obj[Property] extends Mapper["from"]
+        ? Mapper extends { from: infer From; to: infer To }
+            ? Obj[Property] extends From
+                ? To
+                : never
+            : Obj[Property]
+        : Obj[Property];
+};

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -37,6 +37,7 @@ import type {
     Pick,
     PickByType,
     ReplaceKeys,
+    MapTypes,
 } from "../src/utility-types";
 
 describe("Readonly", () => {
@@ -465,5 +466,29 @@ describe("ReplaceKeys", () => {
             foo: number;
             bar: boolean;
         }>();
+    });
+});
+
+describe("MapTypes", () => {
+    test("Replace the types of the keys that match with Mapper type", () => {
+        expectTypeOf<MapTypes<{ foo: string; bar: number }, { from: string; to: number }>>().toEqualTypeOf<{
+            foo: number;
+            bar: number;
+        }>();
+        expectTypeOf<MapTypes<{ foo: number; bar: number }, { from: number; to: string }>>().toEqualTypeOf<{
+            foo: string;
+            bar: string;
+        }>();
+        expectTypeOf<MapTypes<{ foo: string; bar: number }, { from: boolean; to: number }>>().toEqualTypeOf<{
+            foo: string;
+            bar: number;
+        }>();
+        expectTypeOf<MapTypes<{ foo: () => {}; bar: string }, { from: () => {}; to: never }>>().toEqualTypeOf<{
+            foo: never;
+            bar: string;
+        }>();
+        expectTypeOf<
+            MapTypes<{ foo: string; bar: number }, { from: string; to: boolean } | { from: number; to: bigint }>
+        >().toEqualTypeOf<{ foo: boolean; bar: bigint }>();
     });
 });


### PR DESCRIPTION
## Description
This pull request introduces a new utility type called `MapTypes`. This utility type is useful for replacing the types of a series of keys based on the types provided as a second parameter. The second parameter acts as a matcher, verifying if a key's type matches the provided type. If a match is found, the key's type is replaced; otherwise, the original type is retained.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->