### PR TITLE
hotfix: resolve import issues, remove build script and update tsconfig

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "vitest",
     "coverage": "vitest run",
     "build": "tsc",
-    "publish": "tsc && npm run build:js",
+    "publish": "tsc && npm run build",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@halvaradop/ts-utility-types",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Utility types tools to enhances the productivity using typescript",
-  "main": "dist/index.d.ts",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "dev": "tsc -w",
     "test": "vitest",
     "coverage": "vitest run",
-    "build:js": "tsc src/validate-types.ts --outDir dist && rm dist/types.js",
+    "build": "tsc",
     "publish": "tsc && npm run build:js",
     "format": "prettier --write .",
     "format:check": "prettier --check ."

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,7 @@
     "declaration": true,
     "declarationMap": false,
     "declarationDir": "dist",
-    "emitDeclarationOnly": true,
+    "emitDeclarationOnly": false,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true


### PR DESCRIPTION


## Description
This pull request introduces a hotfix for the package, addressing an issue in version `0.6.0.` The problem occurs when users try to import and use a function exported from validate-types.js, but the current entry point of the package has a .d.ts extension, causing an error. The quick solution includes the following changes:

- Fixed an issue preventing users from importing functions available in the package.
- Removed an unnecessary script from the `package.json`.
- Set `emitDeclarationOnly` to false in the `tsconfig.json` to ensure complete type declaration generation.

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->