### PR TITLE
feat: add `Trunc` utility type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -628,6 +628,6 @@ export type Trunc<Math extends string | number | bigint> = `${Math}` extends `.$
     ? "0"
     : `${Math}` extends `${infer Chars}.${number}`
       ? Chars extends `-0${string}`
-        ? "0"
-        : Chars
+          ? "0"
+          : Chars
       : `${Math}`;

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -616,3 +616,18 @@ export type MapTypes<Obj extends object, Mapper extends { from: unknown; to: unk
             : Obj[Property]
         : Obj[Property];
 };
+
+/**
+ * Truncates a number to its integer part.
+ *
+ * @example
+ * type Truncated = Trunc<3.14>; // 3
+ * type TruncatedNegative = Trunc<-2.99>; // -2
+ */
+export type Trunc<Math extends string | number | bigint> = `${Math}` extends `.${number}`
+    ? "0"
+    : `${Math}` extends `${infer Chars}.${number}`
+      ? Chars extends `-0${string}`
+        ? "0"
+        : Chars
+      : `${Math}`;

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -38,6 +38,7 @@ import type {
     PickByType,
     ReplaceKeys,
     MapTypes,
+    Trunc,
 } from "../src/utility-types";
 
 describe("Readonly", () => {
@@ -490,5 +491,17 @@ describe("MapTypes", () => {
         expectTypeOf<
             MapTypes<{ foo: string; bar: number }, { from: string; to: boolean } | { from: number; to: bigint }>
         >().toEqualTypeOf<{ foo: boolean; bar: bigint }>();
+    });
+});
+
+describe("Trunc", () => {
+    test("Truncate a number to its integer part", () => {
+        expectTypeOf<Trunc<3.14159>>().toEqualTypeOf<"3">();
+        expectTypeOf<Trunc<-3.14159>>().toEqualTypeOf<"-3">();
+        expectTypeOf<Trunc<42.1>>().toEqualTypeOf<"42">();
+        expectTypeOf<Trunc<0>>().toEqualTypeOf<"0">();
+        expectTypeOf<Trunc<1289n>>().toEqualTypeOf<"1289">();
+        expectTypeOf<Trunc<-0.98>>().toEqualTypeOf<"0">();
+        expectTypeOf<Trunc<-90000.98>>().toEqualTypeOf<"-90000">();
     });
 });


### PR DESCRIPTION
## Description
This pull request introduces a new utility type called `Trunc`. This type truncates a `number` or `bigint` to its integer part, removing any digits after the decimal point. The result is returned as a string.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->