### PR TITLE
feat: add `ParseUrlParams` string-mapper

### DIFF
--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -184,3 +184,21 @@ export type CheckRepeatedChars<Str extends string, Characters extends string = "
 		? true
 		: CheckRepeatedChars<Chars, Characters | Char>
 	: false;
+
+/**
+ * eturns a union type of the dynamic route parameters in a URL pattern
+ *
+ * @example
+ * type Test1 = ParseUrlParams<"users/:id"> // "id"
+ * type Test2 = ParseUrlParams<"users/:id/posts/:postId"> // "id" | "postId"
+ */
+export type ParseUrlParams<
+	URLParams extends string,
+	Params extends string = never,
+> = URLParams extends `${infer Segment}/${infer Route}`
+	? Segment extends `:${infer WithoutDots}`
+		? ParseUrlParams<Route, Params | WithoutDots>
+		: ParseUrlParams<Route, Params>
+	: URLParams extends `:${infer WithoutDots}`
+		? Params | WithoutDots
+		: Params;

--- a/testing/string-mappers.test.ts
+++ b/testing/string-mappers.test.ts
@@ -16,6 +16,7 @@ import type {
 	FirstUniqueCharIndex,
 	Replace,
 	CheckRepeatedChars,
+	ParseUrlParams,
 } from "../src/string-mappers";
 
 describe("String mappers", () => {
@@ -140,5 +141,15 @@ describe("CheckRepeatedChars", () => {
 		expectTypeOf<CheckRepeatedChars<"aba">>().toEqualTypeOf<true>();
 		expectTypeOf<CheckRepeatedChars<"abcza">>().toEqualTypeOf<true>();
 		expectTypeOf<CheckRepeatedChars<"añlamnhj">>().toEqualTypeOf<true>();
+	});
+});
+
+describe("ParseUrlParams", () => {
+	test("Parse the URL parameters", () => {
+		expectTypeOf<ParseUrlParams<"posts/:id">>().toEqualTypeOf<"id">();
+		expectTypeOf<ParseUrlParams<":posts/:id">>().toEqualTypeOf<"posts" | "id">();
+		expectTypeOf<ParseUrlParams<"user/:id/posts/:postId">>().toEqualTypeOf<"id" | "postId">();
+		expectTypeOf<ParseUrlParams<":posts/:id">>().toEqualTypeOf<"posts" | "id">();
+		expectTypeOf<ParseUrlParams<"posts/:id/:items/likes">>().toEqualTypeOf<"id" | "items">();
 	});
 });


### PR DESCRIPTION
## Description
This pull request introduces a new string mapper called `ParseUrlParams`, which returns the dynamic route parameters of a `URL`. The dynamic routes are identified by double colons `:`.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->