### PR TITLE
feat: add `FindAll` string-mapper

### DIFF
--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -202,3 +202,23 @@ export type ParseUrlParams<
 	: URLParams extends `:${infer WithoutDots}`
 		? Params | WithoutDots
 		: Params;
+
+/**
+ * Returns indexes the substring that matches `Match` in the string `Str`
+ *
+ * @example
+ * type Test1 = FindAll<"hello world", "o"> // [4, 7]
+ * type Test2 = FindAll<"hello world", "l"> // [2, 3, 9]
+ */
+export type FindAll<
+	Str extends string,
+	Match extends string,
+	Index extends unknown[] = [],
+	Indexes extends unknown[] = [],
+> = Match extends ""
+	? Indexes
+	: Str extends `${infer Char}${infer Characters}`
+		? Str extends `${Match}${string}`
+			? FindAll<Characters, Match, [...Index, 1], [...Indexes, Index["length"]]>
+			: FindAll<Characters, Match, [...Index, 1], Indexes>
+		: Indexes;

--- a/testing/string-mappers.test.ts
+++ b/testing/string-mappers.test.ts
@@ -17,6 +17,7 @@ import type {
 	Replace,
 	CheckRepeatedChars,
 	ParseUrlParams,
+	FindAll,
 } from "../src/string-mappers";
 
 describe("String mappers", () => {
@@ -151,5 +152,16 @@ describe("ParseUrlParams", () => {
 		expectTypeOf<ParseUrlParams<"user/:id/posts/:postId">>().toEqualTypeOf<"id" | "postId">();
 		expectTypeOf<ParseUrlParams<":posts/:id">>().toEqualTypeOf<"posts" | "id">();
 		expectTypeOf<ParseUrlParams<"posts/:id/:items/likes">>().toEqualTypeOf<"id" | "items">();
+	});
+});
+
+describe("FindAll", () => {
+	test("Find all the indexes of a substring in a string", () => {
+		expectTypeOf<FindAll<"", "">>().toEqualTypeOf<[]>();
+		expectTypeOf<FindAll<"ooooo", "">>().toEqualTypeOf<[]>();
+		expectTypeOf<FindAll<"", "foobar">>().toEqualTypeOf<[]>();
+		expectTypeOf<FindAll<"foobar", "o">>().toEqualTypeOf<[1, 2]>();
+		expectTypeOf<FindAll<"foooo", "o">>().toEqualTypeOf<[1, 2, 3, 4]>();
+		expectTypeOf<FindAll<"ooooo", "oo">>().toEqualTypeOf<[0, 1, 2, 3]>();
 	});
 });


### PR DESCRIPTION
## Description
This pull request introduces a new string mapper type called `FindAll` that returns the indexes of all substrings that match the Match parameter provided in the string-mapper utility. 


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->