### PR TITLE
feat: add `DeepOmit` utility type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -631,3 +631,35 @@ export type Trunc<Math extends string | number | bigint> = `${Math}` extends `.$
 			? "0"
 			: Chars
 		: `${Math}`;
+
+/**
+ * Omits properties of an object at any depth based on the provided pattern.
+ *
+ * @example
+ * type User = {
+ *   name: string,
+ *   address: {
+ *     street: string,
+ *     avenue: string
+ *   }
+ * }
+ *
+ * // Expected: { name: string, address: { street: string } }
+ * type OmitAvenueUser = DeepOmit<User, "addresss.avenue">
+ *
+ * // Expected: { address: { street: string, avenue: string } }
+ * type OmitNameUser = DeepOmit<User, "name">
+ */
+export type DeepOmit<Obj extends object, Pattern extends string> = {
+	[Property in keyof Obj as Pattern extends `${string}.${string}`
+		? Property
+		: Property extends Pattern
+			? never
+			: Property]: Pattern extends `${infer StartsWith}.${infer Spread}`
+		? Property extends StartsWith
+			? Obj[Property] extends object
+				? DeepOmit<Obj[Property], Spread>
+				: Obj[Property]
+			: Obj[Property]
+		: Obj[Property];
+};

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -39,6 +39,7 @@ import type {
 	ReplaceKeys,
 	MapTypes,
 	Trunc,
+	DeepOmit,
 } from "../src/utility-types";
 
 describe("Readonly", () => {
@@ -503,5 +504,24 @@ describe("Trunc", () => {
 		expectTypeOf<Trunc<1289n>>().toEqualTypeOf<"1289">();
 		expectTypeOf<Trunc<-0.98>>().toEqualTypeOf<"0">();
 		expectTypeOf<Trunc<-90000.98>>().toEqualTypeOf<"-90000">();
+	});
+});
+
+describe("DeepOmit", () => {
+	test("Omit properties from nested objects", () => {
+		expectTypeOf<DeepOmit<{ foo: string; bar: { foobar: number } }, "foo">>().toEqualTypeOf<{
+			bar: { foobar: number };
+		}>();
+		expectTypeOf<DeepOmit<{ foo: string; bar: { foobar: number } }, "bar.foobar">>().toEqualTypeOf<{
+			foo: string;
+			bar: {};
+		}>();
+		expectTypeOf<DeepOmit<{ foo: string; bar: { foobar: number } }, "foobar">>().toEqualTypeOf<{
+			foo: string;
+			bar: { foobar: number };
+		}>();
+		expectTypeOf<DeepOmit<{ foo: string; bar: { foobar: number, nested: { baz: string } } }, "bar.nested.baz">>().toEqualTypeOf<{
+            foo: string; bar: { foobar: number, nested: {} };
+        }>();
 	});
 });

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -520,8 +520,11 @@ describe("DeepOmit", () => {
 			foo: string;
 			bar: { foobar: number };
 		}>();
-		expectTypeOf<DeepOmit<{ foo: string; bar: { foobar: number, nested: { baz: string } } }, "bar.nested.baz">>().toEqualTypeOf<{
-            foo: string; bar: { foobar: number, nested: {} };
-        }>();
+		expectTypeOf<
+			DeepOmit<{ foo: string; bar: { foobar: number; nested: { baz: string } } }, "bar.nested.baz">
+		>().toEqualTypeOf<{
+			foo: string;
+			bar: { foobar: number; nested: {} };
+		}>();
 	});
 });


### PR DESCRIPTION
## Description
This pull request introduces a new utility type called `DeepOmit`, which allows omitting a nested property at any level of the provided object. This can be useful if the user wants to omit a deeply nested property. With this utility type, the user can specify the property to be removed.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->