### PR TITLE
feat: add `Chuck` utility type

### DIFF
--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -663,3 +663,18 @@ export type DeepOmit<Obj extends object, Pattern extends string> = {
 			: Obj[Property]
 		: Obj[Property];
 };
+
+type ChunkImplementation<
+	Array extends unknown[],
+	Size extends number,
+	Build extends unknown[] = [],
+	Partition extends unknown[] = [],
+> = Array extends [infer Item, ...infer Spread]
+	? [...Partition, Item]["length"] extends Size
+		? ChunkImplementation<Spread, Size, [...Build, [...Partition, Item]], []>
+		: ChunkImplementation<Spread, Size, Build, [...Partition, Item]>
+	: Partition["length"] extends 0
+		? Build
+		: [...Build, Partition];
+
+export type Chunk<Array extends unknown[], Size extends number> = ChunkImplementation<Array, Size, [], []>;

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -40,6 +40,7 @@ import type {
 	MapTypes,
 	Trunc,
 	DeepOmit,
+	Chunk,
 } from "../src/utility-types";
 
 describe("Readonly", () => {
@@ -526,5 +527,17 @@ describe("DeepOmit", () => {
 			foo: string;
 			bar: { foobar: number; nested: {} };
 		}>();
+	});
+});
+
+describe("Chunk", () => {
+	test("Split an array into chunks", () => {
+		expectTypeOf<Chunk<[1, 2, 3, 4, 5], 1>>().toEqualTypeOf<[[1], [2], [3], [4], [5]]>();
+		expectTypeOf<Chunk<[1, 2, 3, 4, 5], 2>>().toEqualTypeOf<[[1, 2], [3, 4], [5]]>();
+		expectTypeOf<Chunk<[1, 2, 3, 4, 5], 3>>().toEqualTypeOf<[[1, 2, 3], [4, 5]]>();
+		expectTypeOf<Chunk<[1, 2, 3, 4, 5], 4>>().toEqualTypeOf<[[1, 2, 3, 4], [5]]>();
+		expectTypeOf<Chunk<[1, 2, 3, 4, 5], 5>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
+		expectTypeOf<Chunk<[1, 2, 3, 4, 5], 6>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
+		expectTypeOf<Chunk<[1, 2, 3, 4, 5], -2>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
 	});
 });


### PR DESCRIPTION
## Description
This pull request introduces a new utility type called `Chunk`, which partitions a tuple into multiple chunks or a single chunk. This utility type is similar to the chunk function provided by the Lodash library and can be useful for splitting a tuple into smaller parts.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->