### PR TITLE
feat: add `Zip` utility type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ export type {
 	Chunk,
 	DeepOmit,
 	Trunc,
+	Zip
 } from "./utility-types.js";
 
 export type {

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -707,3 +707,21 @@ type ChunkImplementation<
 		: [...Build, Partition];
 
 export type Chunk<Array extends unknown[], Size extends number> = ChunkImplementation<Array, Size, [], []>;
+
+type ZipImplementation<T, U, Build extends unknown[] = []> = T extends [infer ItemT, ...infer SpreadT]
+	? U extends [infer ItemU, ...infer SpreadU]
+		? ZipImplementation<SpreadT, SpreadU, [...Build, [ItemT, ItemU]]>
+		: Build
+	: Build;
+
+/**
+ * Join the elements of two arrays in a tuple of arrays
+ *
+ * @example
+ * // Expected: [[1, "a"], [2, "b"], [3, "c"]]
+ * type Zip1 = Zip<[1, 2, 3], ["a", "b", "c"]>
+ *
+ * // Expected: [[1, "a"], [2, "b"]]
+ * type Zip2 = Zip<[1, 2, 3], ["a", "b"]>
+ */
+export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = ZipImplementation<Array1, Array2>;

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -41,6 +41,7 @@ import type {
 	Trunc,
 	DeepOmit,
 	Chunk,
+	Zip,
 } from "../src/utility-types";
 
 describe("Readonly", () => {
@@ -539,5 +540,16 @@ describe("Chunk", () => {
 		expectTypeOf<Chunk<[1, 2, 3, 4, 5], 5>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
 		expectTypeOf<Chunk<[1, 2, 3, 4, 5], 6>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
 		expectTypeOf<Chunk<[1, 2, 3, 4, 5], -2>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
+	});
+});
+
+describe("Zip", () => {
+	test("Zip two arrays into a tuple", () => {
+		expectTypeOf<Zip<[], []>>().toEqualTypeOf<[]>();
+		expectTypeOf<Zip<[1, 2, 3], ["foo"]>>().toEqualTypeOf<[[1, "foo"]]>();
+		expectTypeOf<Zip<[1, "bar", 3], ["foo", 2]>>().toEqualTypeOf<[[1, "foo"], ["bar", 2]]>();
+		expectTypeOf<Zip<[{ foo: string }, { bar: string }], ["foo", "bar"]>>().toEqualTypeOf<
+			[[{ foo: string }, "foo"], [{ bar: string }, "bar"]]
+		>();
 	});
 });


### PR DESCRIPTION
## Description
This pull request introduces a new utility type called `Zip`, which joins the elements of two tuples to create a single tuple. It only combines the elements up to the minimum length of the two tuples.

## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->