### PR TITLE
feat: add `ToPrimitive` utility type and add `ReturnTypeOf` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,8 @@ export type {
 	Chunk,
 	DeepOmit,
 	Trunc,
-	Zip
+	Zip,
+	ToPrimitive,
 } from "./utility-types.js";
 
 export type {
@@ -57,6 +58,7 @@ export type {
 	Falsy,
 	Even,
 	Odd,
+	ReturnTypeOf,
 } from "./types.js";
 
 export {

--- a/src/types.ts
+++ b/src/types.ts
@@ -120,15 +120,15 @@ export type Even = 0 | 2 | 4 | 6 | 8;
 
 /**
  * Determines the primitive type corresponding to the provided value.
- * 
+ *
  * @example
  * // Expected: number
- * type TypeOfValue = TypeOf<123> 
- * 
+ * type TypeOfValue = TypeOf<123>
+ *
  * // Expected: string
  * type TypeOfValue = TypeOf<"hello">
  */
-export type ReturnTypeOf<T> = T extends string	
+export type ReturnTypeOf<T> = T extends string
 	? string
 	: T extends number
 		? number

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,3 +117,25 @@ export type Odd = 1 | 3 | 5 | 7 | 9;
  * The even digits
  */
 export type Even = 0 | 2 | 4 | 6 | 8;
+
+/**
+ * Determines the primitive type corresponding to the provided value.
+ * 
+ * @example
+ * // Expected: number
+ * type TypeOfValue = TypeOf<123> 
+ * 
+ * // Expected: string
+ * type TypeOfValue = TypeOf<"hello">
+ */
+export type ReturnTypeOf<T> = T extends string	
+	? string
+	: T extends number
+		? number
+		: T extends object
+			? object
+			: T extends boolean
+				? boolean
+				: T extends Function
+					? Function
+					: never;

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,6 +1,6 @@
 import type { DropChar } from "./string-mappers";
 import type { Equals } from "./test";
-import type { ArgsFunction } from "./types";
+import type { ArgsFunction, ReturnTypeOf } from "./types";
 
 /**
  * Utility type that transforms an object to have each property on a new line
@@ -725,3 +725,25 @@ type ZipImplementation<T, U, Build extends unknown[] = []> = T extends [infer It
  * type Zip2 = Zip<[1, 2, 3], ["a", "b"]>
  */
 export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = ZipImplementation<Array1, Array2>;
+
+/**
+ * Transforms the object properties to their primitive types. If the properties are objects,
+ * it recursively transforms their properties to their primitive types, and so on.
+ * 
+ * @example
+ * interface User {
+ *   name: "Foo",
+ *   lastname: "Bar",
+ *   age: 30
+ * }
+ * 
+ * // Expected: { name: string, lastname: string, age: number }
+ * type UserPrimitive = ToPrimitive<User>
+ */
+export type ToPrimitive<Obj extends object> = {
+	[Property in keyof Obj]: Obj[Property] extends object 
+		? Obj[Property] extends Function
+			? Function
+			: ToPrimitive<Obj[Property]>
+		: ReturnTypeOf<Obj[Property]>
+}

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -729,21 +729,21 @@ export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = ZipImpleme
 /**
  * Transforms the object properties to their primitive types. If the properties are objects,
  * it recursively transforms their properties to their primitive types, and so on.
- * 
+ *
  * @example
  * interface User {
  *   name: "Foo",
  *   lastname: "Bar",
  *   age: 30
  * }
- * 
+ *
  * // Expected: { name: string, lastname: string, age: number }
  * type UserPrimitive = ToPrimitive<User>
  */
 export type ToPrimitive<Obj extends object> = {
-	[Property in keyof Obj]: Obj[Property] extends object 
+	[Property in keyof Obj]: Obj[Property] extends object
 		? Obj[Property] extends Function
 			? Function
 			: ToPrimitive<Obj[Property]>
-		: ReturnTypeOf<Obj[Property]>
-}
+		: ReturnTypeOf<Obj[Property]>;
+};

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -42,7 +42,7 @@ import type {
 	DeepOmit,
 	Chunk,
 	Zip,
-	ToPrimitive
+	ToPrimitive,
 } from "../src/utility-types";
 
 describe("Readonly", () => {
@@ -557,9 +557,12 @@ describe("Zip", () => {
 
 describe("ToPrimitive", () => {
 	test("Converts a string to a primitive type", () => {
-		expectTypeOf<ToPrimitive<{ foo: string, bar: string }>>().toEqualTypeOf<{ foo: string, bar: string }>();
-		expectTypeOf<ToPrimitive<{ foo: "foobar", bar: string }>>().toEqualTypeOf<{ foo: string, bar: string }>();
-		expectTypeOf<ToPrimitive<{ foo: "foobar", bar: 12 }>>().toEqualTypeOf<{ foo: string, bar: number }>();
-		expectTypeOf<ToPrimitive<{ foo: { foobar: "fo", bar: false }, bar: 12 }>>().toEqualTypeOf<{ foo: { foobar: string, bar: boolean }, bar: number }>();
+		expectTypeOf<ToPrimitive<{ foo: string; bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
+		expectTypeOf<ToPrimitive<{ foo: "foobar"; bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
+		expectTypeOf<ToPrimitive<{ foo: "foobar"; bar: 12 }>>().toEqualTypeOf<{ foo: string; bar: number }>();
+		expectTypeOf<ToPrimitive<{ foo: { foobar: "fo"; bar: false }; bar: 12 }>>().toEqualTypeOf<{
+			foo: { foobar: string; bar: boolean };
+			bar: number;
+		}>();
 	});
 });

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -42,6 +42,7 @@ import type {
 	DeepOmit,
 	Chunk,
 	Zip,
+	ToPrimitive
 } from "../src/utility-types";
 
 describe("Readonly", () => {
@@ -551,5 +552,14 @@ describe("Zip", () => {
 		expectTypeOf<Zip<[{ foo: string }, { bar: string }], ["foo", "bar"]>>().toEqualTypeOf<
 			[[{ foo: string }, "foo"], [{ bar: string }, "bar"]]
 		>();
+	});
+});
+
+describe("ToPrimitive", () => {
+	test("Converts a string to a primitive type", () => {
+		expectTypeOf<ToPrimitive<{ foo: string, bar: string }>>().toEqualTypeOf<{ foo: string, bar: string }>();
+		expectTypeOf<ToPrimitive<{ foo: "foobar", bar: string }>>().toEqualTypeOf<{ foo: string, bar: string }>();
+		expectTypeOf<ToPrimitive<{ foo: "foobar", bar: 12 }>>().toEqualTypeOf<{ foo: string, bar: number }>();
+		expectTypeOf<ToPrimitive<{ foo: { foobar: "fo", bar: false }, bar: 12 }>>().toEqualTypeOf<{ foo: { foobar: string, bar: boolean }, bar: number }>();
 	});
 });


### PR DESCRIPTION
## Description
This pull request introduces a new utility type called `ToPrimitive`, which recursively converts the properties of an object to their primitive values. Additionally, it adds the `ReturnTypeOf` type, which returns the `typeof` a value.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->