### PR TITLE
chore(docs): improve return types in examples

### DIFF
--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -5,7 +5,7 @@ import type { LetterToLowercase, LetterToUppercase, WhiteSpaces } from "./types"
  * Removes leading whitespace characters from a string type
  * @example
  * // Expected: "hello world  "
- * type TrimmedLeft = TrimLeft<"  hello world  ">; 
+ * type TrimmedLeft = TrimLeft<"  hello world  ">;
  */
 export type TrimLeft<Str extends string> = Str extends `${WhiteSpaces}${infer Characters}` ? TrimLeft<Characters> : Str;
 
@@ -13,7 +13,7 @@ export type TrimLeft<Str extends string> = Str extends `${WhiteSpaces}${infer Ch
  * Removes trailing whitespace characters from a string type
  * @example
  * // Expected: "hello world"
- * type TrimmedRight = TrimRight<"hello world  ">; 
+ * type TrimmedRight = TrimRight<"hello world  ">;
  */
 export type TrimRight<Str extends string> = Str extends `${infer Char}${WhiteSpaces}` ? TrimRight<Char> : Str;
 
@@ -21,7 +21,7 @@ export type TrimRight<Str extends string> = Str extends `${infer Char}${WhiteSpa
  * Removes leading and trailing whitespace characters from a string type
  * @example
  * // Expected: "hello world"
- * type Trimmed = Trim<"  hello world  ">; 
+ * type Trimmed = Trim<"  hello world  ">;
  */
 export type Trim<Str extends string> = Str extends `${WhiteSpaces}${infer Characters}`
 	? Trim<Characters>
@@ -73,8 +73,8 @@ type JoinImplementation<Array extends unknown[], Separator extends number | stri
  *
  * @example
  * // Expected: "a-p-p-l-e"
- * type Join1 = Join<["a", "p", "p", "l", "e"], "-"> 
- * 
+ * type Join1 = Join<["a", "p", "p", "l", "e"], "-">
+ *
  * // Expected: "Hello World"
  * type Join2 = Join<["Hello", "World"], " ">
  */
@@ -85,13 +85,13 @@ export type Join<Array extends unknown[], Separator extends number | string> = J
  *
  * @example
  * // Expected: false
- * type Test1 = StartsWith<"abc", "ac"> 
- * 
+ * type Test1 = StartsWith<"abc", "ac">
+ *
  * // Expected: true
- * type Test2 = StartsWith<"abc", "ab"> 
- * 
+ * type Test2 = StartsWith<"abc", "ab">
+ *
  * // Expected: false
- * type Test3 = StartsWith<"abc", "abcd"> 
+ * type Test3 = StartsWith<"abc", "abcd">
  */
 export type StartsWith<Str extends string, Match extends string> = Str extends `${Match}${string}` ? true : false;
 
@@ -108,7 +108,7 @@ type DropCharImplementation<
  *
  * @example
  * // Expected: butterfly!
- * type Test1 = DropChar<"butter fly!", ""> 
+ * type Test1 = DropChar<"butter fly!", "">
  * // Expected: "butterfly!"
  * type Test2 = DropChar<" b u t t e r f l y ! ", " ">
  */
@@ -119,10 +119,10 @@ export type DropChar<Str extends string, Match extends string> = DropCharImpleme
  *
  * @example
  * // Expected: true
- * type Test1 = EndsWith<"abc", "bc"> 
- * 
+ * type Test1 = EndsWith<"abc", "bc">
+ *
  * // Expected: false
- * type Test2 = EndsWith<"abc", "ac"> 
+ * type Test2 = EndsWith<"abc", "ac">
  */
 export type EndsWith<Str extends string, Match extends string> = Str extends `${string}${Match}` ? true : false;
 
@@ -135,10 +135,10 @@ type LengthOfStringImplementation<Str extends string, Length extends unknown[] =
  *
  * @example
  * // Expected: 3
- * type Length2 = LengthOfString<"foo"> 
- * 
+ * type Length2 = LengthOfString<"foo">
+ *
  * // Expected: 6
- * type Length6 = LengthOfString<"foobar"> 
+ * type Length6 = LengthOfString<"foobar">
  */
 export type LengthOfString<Str extends string> = LengthOfStringImplementation<Str>;
 
@@ -158,10 +158,10 @@ type IndexOfStringImplementation<
  *
  * @example
  * // Expected: 12
- * type IndexOfA = IndexOfString<"comparator is a function", "i"> 
- * 
+ * type IndexOfA = IndexOfString<"comparator is a function", "i">
+ *
  * // Expected: -1
- * type IndexOfOutBound = IndexOfString<"comparator is a function", "z"> 
+ * type IndexOfOutBound = IndexOfString<"comparator is a function", "z">
  */
 export type IndexOfString<Str extends string, Match extends string> = IndexOfStringImplementation<Str, Match>;
 
@@ -183,10 +183,10 @@ type FirstUniqueCharIndexImplementation<
  *
  * @example
  * // Expected: 3
- * type IndexOfC = FirstUniqueCharIndex<"aabcb"> 
- * 
+ * type IndexOfC = FirstUniqueCharIndex<"aabcb">
+ *
  * // Expected: -1
- * type IndexOfOutBound = FirstUniqueCharIndex<"aabbcc"> 
+ * type IndexOfOutBound = FirstUniqueCharIndex<"aabbcc">
  */
 export type FirstUniqueCharIndex<Str extends string> = FirstUniqueCharIndexImplementation<Str>;
 
@@ -195,10 +195,10 @@ export type FirstUniqueCharIndex<Str extends string> = FirstUniqueCharIndexImple
  *
  * @example
  * // Expected: "foofoo"
- * type Replace1 = Replace<"foobar", "bar", "foo"> 
- * 
+ * type Replace1 = Replace<"foobar", "bar", "foo">
+ *
  * // Expected: "foofoobar"
- * type Replace2 = Replace<"foobarbar", "bar", "foo"> 
+ * type Replace2 = Replace<"foobarbar", "bar", "foo">
  */
 export type Replace<S extends string, From extends string, To extends string> = From extends ""
 	? S
@@ -243,10 +243,10 @@ type ParseUrlParamsImplementation<
  *
  * @example
  * // Expected: "id"
- * type Test1 = ParseUrlParams<"users/:id"> 
- * 
+ * type Test1 = ParseUrlParams<"users/:id">
+ *
  * // Expected: "id" | "postId"
- * type Test2 = ParseUrlParams<"users/:id/posts/:postId"> 
+ * type Test2 = ParseUrlParams<"users/:id/posts/:postId">
  */
 export type ParseUrlParams<URLParams extends string> = ParseUrlParamsImplementation<URLParams>;
 
@@ -268,9 +268,9 @@ type FindAllImplementation<
  *
  * @example
  * // Expected: [4, 7]
- * type Test1 = FindAll<"hello world", "o"> 
- * 
+ * type Test1 = FindAll<"hello world", "o">
+ *
  * // Expected: [2, 3, 9]
- * type Test2 = FindAll<"hello world", "l"> 
+ * type Test2 = FindAll<"hello world", "l">
  */
 export type FindAll<Str extends string, Match extends string> = FindAllImplementation<Str, Match>;

--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -4,24 +4,24 @@ import type { LetterToLowercase, LetterToUppercase, WhiteSpaces } from "./types"
 /**
  * Removes leading whitespace characters from a string type
  * @example
- * type Str = "  hello world  ";
- * type TrimmedLeft = TrimLeft<Str>; // TrimmedLeft = "hello world  "
+ * // Expected: "hello world  "
+ * type TrimmedLeft = TrimLeft<"  hello world  ">; 
  */
 export type TrimLeft<Str extends string> = Str extends `${WhiteSpaces}${infer Characters}` ? TrimLeft<Characters> : Str;
 
 /**
  * Removes trailing whitespace characters from a string type
  * @example
- * type Str = "hello world  ";
- * type TrimmedRight = TrimRight<Str>; // TrimmedRight = "hello world"
+ * // Expected: "hello world"
+ * type TrimmedRight = TrimRight<"hello world  ">; 
  */
 export type TrimRight<Str extends string> = Str extends `${infer Char}${WhiteSpaces}` ? TrimRight<Char> : Str;
 
 /**
  * Removes leading and trailing whitespace characters from a string type
  * @example
- * type Str = "  hello world  ";
- * type Trimmed = Trim<Str>; // Trimmed = "hello world"
+ * // Expected: "hello world"
+ * type Trimmed = Trim<"  hello world  ">; 
  */
 export type Trim<Str extends string> = Str extends `${WhiteSpaces}${infer Characters}`
 	? Trim<Characters>
@@ -72,8 +72,11 @@ type JoinImplementation<Array extends unknown[], Separator extends number | stri
  * separated by the `Separator` character. The separator can be either a string or a number.
  *
  * @example
- * type Join1 = Join<["a", "p", "p", "l", "e"], "-"> // "a-p-p-l-e"
- * type Join2 = Join<["Hello", "World"], " "> // "Hello World"
+ * // Expected: "a-p-p-l-e"
+ * type Join1 = Join<["a", "p", "p", "l", "e"], "-"> 
+ * 
+ * // Expected: "Hello World"
+ * type Join2 = Join<["Hello", "World"], " ">
  */
 export type Join<Array extends unknown[], Separator extends number | string> = JoinImplementation<Array, Separator>;
 
@@ -81,9 +84,14 @@ export type Join<Array extends unknown[], Separator extends number | string> = J
  * Checks if a string type matchs start with a strig `U`
  *
  * @example
- * type Test1 = StartsWith<'abc', 'ac'> // false
- * type Test2 = StartsWith<'abc', 'ab'> // true
- * type Test3 = StartsWith<'abc', 'abcd'> // false
+ * // Expected: false
+ * type Test1 = StartsWith<"abc", "ac"> 
+ * 
+ * // Expected: true
+ * type Test2 = StartsWith<"abc", "ab"> 
+ * 
+ * // Expected: false
+ * type Test3 = StartsWith<"abc", "abcd"> 
  */
 export type StartsWith<Str extends string, Match extends string> = Str extends `${Match}${string}` ? true : false;
 
@@ -99,8 +107,10 @@ type DropCharImplementation<
  * Returns a new string type by removing all occurrences of the character `Match` from the string `Str`
  *
  * @example
- * type Test1 = DropChar<'butter fly!', ''> // butterfly!
- * type Test2 = DropChar<' b u t t e r f l y ! ', ' '> // 'butterfly!'
+ * // Expected: butterfly!
+ * type Test1 = DropChar<"butter fly!", ""> 
+ * // Expected: "butterfly!"
+ * type Test2 = DropChar<" b u t t e r f l y ! ", " ">
  */
 export type DropChar<Str extends string, Match extends string> = DropCharImplementation<Str, Match>;
 
@@ -108,8 +118,11 @@ export type DropChar<Str extends string, Match extends string> = DropCharImpleme
  * Checks if a string type matchs start with a strig `Match`
  *
  * @example
- * type Test1 = EndsWith<'abc', 'bc'> // true
- * type Test2 = EndsWith<'abc', 'ac'> // false
+ * // Expected: true
+ * type Test1 = EndsWith<"abc", "bc"> 
+ * 
+ * // Expected: false
+ * type Test2 = EndsWith<"abc", "ac"> 
  */
 export type EndsWith<Str extends string, Match extends string> = Str extends `${string}${Match}` ? true : false;
 
@@ -121,8 +134,11 @@ type LengthOfStringImplementation<Str extends string, Length extends unknown[] =
  * Returns the length of a string type
  *
  * @example
- * type Length2 = LengthOfString<"foo"> // 3
- * type Length6 = LengthOfString<"foobar"> // 6
+ * // Expected: 3
+ * type Length2 = LengthOfString<"foo"> 
+ * 
+ * // Expected: 6
+ * type Length6 = LengthOfString<"foobar"> 
  */
 export type LengthOfString<Str extends string> = LengthOfStringImplementation<Str>;
 
@@ -141,8 +157,11 @@ type IndexOfStringImplementation<
  * Otherwise, it returns -1.
  *
  * @example
- * type IndexOfA = IndexOfString<"comparator is a function", "i"> // 12
- * type IndexOfOutBound = IndexOfString<"comparator is a function", "z"> // -1
+ * // Expected: 12
+ * type IndexOfA = IndexOfString<"comparator is a function", "i"> 
+ * 
+ * // Expected: -1
+ * type IndexOfOutBound = IndexOfString<"comparator is a function", "z"> 
  */
 export type IndexOfString<Str extends string, Match extends string> = IndexOfStringImplementation<Str, Match>;
 
@@ -163,8 +182,11 @@ type FirstUniqueCharIndexImplementation<
  * If all of the characters are repeated, it returns -1.
  *
  * @example
- * type IndexOfC = FirstUniqueCharIndex<"aabcb"> // 3
- * type IndexOfOutBound = FirstUniqueCharIndex<"aabbcc"> // -1
+ * // Expected: 3
+ * type IndexOfC = FirstUniqueCharIndex<"aabcb"> 
+ * 
+ * // Expected: -1
+ * type IndexOfOutBound = FirstUniqueCharIndex<"aabbcc"> 
  */
 export type FirstUniqueCharIndex<Str extends string> = FirstUniqueCharIndexImplementation<Str>;
 
@@ -172,8 +194,11 @@ export type FirstUniqueCharIndex<Str extends string> = FirstUniqueCharIndexImple
  * Replaces the first match of the substring `From` in the string `S` with the new value `To`
  *
  * @example
- * type Replace1 = Replace<'foobar', 'bar', 'foo'> // 'foofoo'
- * type Replace2 = Replace<'foobarbar', 'bar', 'foo'> // 'foofoobar'
+ * // Expected: "foofoo"
+ * type Replace1 = Replace<"foobar", "bar", "foo"> 
+ * 
+ * // Expected: "foofoobar"
+ * type Replace2 = Replace<"foobarbar", "bar", "foo"> 
  */
 export type Replace<S extends string, From extends string, To extends string> = From extends ""
 	? S
@@ -194,11 +219,11 @@ type CheckRepeatedCharsImplementation<
  * Check if there are repeated characters in a string type
  *
  * @example
- * // Expected: No repeated characters
- * type Check11 = CheckRepeatedChars<"hello"> // false
+ * // Expected: false
+ * type Check11 = CheckRepeatedChars<"hello">
  *
- * // Expected: Repeated characters
- * type Check1 = CheckRepeatedChars<"hello world"> // true
+ * // Expected: true
+ * type Check1 = CheckRepeatedChars<"hello world">
  */
 export type CheckRepeatedChars<Str extends string> = CheckRepeatedCharsImplementation<Str>;
 
@@ -217,8 +242,11 @@ type ParseUrlParamsImplementation<
  * eturns a union type of the dynamic route parameters in a URL pattern
  *
  * @example
- * type Test1 = ParseUrlParams<"users/:id"> // "id"
- * type Test2 = ParseUrlParams<"users/:id/posts/:postId"> // "id" | "postId"
+ * // Expected: "id"
+ * type Test1 = ParseUrlParams<"users/:id"> 
+ * 
+ * // Expected: "id" | "postId"
+ * type Test2 = ParseUrlParams<"users/:id/posts/:postId"> 
  */
 export type ParseUrlParams<URLParams extends string> = ParseUrlParamsImplementation<URLParams>;
 
@@ -239,7 +267,10 @@ type FindAllImplementation<
  * Returns indexes the substring that matches `Match` in the string `Str`
  *
  * @example
- * type Test1 = FindAll<"hello world", "o"> // [4, 7]
- * type Test2 = FindAll<"hello world", "l"> // [2, 3, 9]
+ * // Expected: [4, 7]
+ * type Test1 = FindAll<"hello world", "o"> 
+ * 
+ * // Expected: [2, 3, 9]
+ * type Test2 = FindAll<"hello world", "l"> 
  */
 export type FindAll<Str extends string, Match extends string> = FindAllImplementation<Str, Match>;

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -23,7 +23,7 @@ export type Prettify<Obj extends object> = {
  *     avenue: string
  *   }
  * };
- * 
+ *
  * // Expected: { readonly name: string, readonly address: { readonly street: string, readonly avenue: string } }
  * type ReadonlyUser = DeepReadonly<User>;
  */
@@ -53,7 +53,7 @@ export type TupleToUnion<Array extends readonly unknown[]> = Array extends [infe
  * @example
  * const numbers: number[] = [1, 2, 3, 4, 5];
  * // Expected: 5
- * type SizeOfNumbers = Size<typeof numbers>; 
+ * type SizeOfNumbers = Size<typeof numbers>;
  */
 export type Size<Array extends unknown[]> = Array extends unknown[] ? Array["length"] : 0;
 
@@ -73,7 +73,7 @@ export type Last<Array extends unknown[]> = Array extends [...any, infer Last] ?
  * @example
  * // Expected: ["a", "b"]
  * type PopStr = Pop<["a", "b", "c"]>;
- * 
+ *
  * // Expected: [1, 2]
  * type PopNums = Pop<[1, 2, 3]>;
  */
@@ -101,7 +101,7 @@ export type Awaited<T extends PromiseLike<unknown>> =
  * function add(x: number, y: number): number {
  *   return x + y;
  * };
- * 
+ *
  * // Expected: [number, number]
  * type AddParams = Parameters<typeof add>;
  */
@@ -116,7 +116,7 @@ export type Parameters<Function extends ArgsFunction> = Function extends (...arg
  *   lastname: string,
  *   age: number
  * };
- * 
+ *
  * // Expected: { age: number }
  * type PickUser = Pick<User, "age">;
  */
@@ -130,10 +130,10 @@ export type Pick<Obj extends object, Keys extends keyof Obj> = {
  * @example
  * // Expected: true
  * type IncludesNumber = Includes<[1, 2, 3], 3>;
- * 
+ *
  * // Expected: true
  * type IncludesString = Includes<["foo", "bar", "foobar"], "bar">;
- * 
+ *
  * // Expected: false
  * type NoIncludes = Includes<["foo", "bar", "foofoo"], "foobar">;
  */
@@ -207,7 +207,7 @@ export type Merge<Obj1 extends object, Obj2 extends object> = {
  *   age: string
  *   gender: number
  * };
- * 
+ *
  * // Expected: { gender: number }
  * type DiffFoo = Intersection<Foo, Bar>;
  */
@@ -228,7 +228,7 @@ export type Intersection<Obj1 extends object, Obj2 extends object> = {
  *   lastname: string,
  *   age: number
  * };
- * 
+ *
  * // Expected: { name: string, lastname: string }
  * type UserStr = PickByType<User, string>;
  */
@@ -245,7 +245,7 @@ export type PickByType<Obj extends object, Type> = {
  *   lastname: string,
  *   age: number
  * };
- * 
+ *
  * // Expected: { name?: string, lastname: string, age: number }
  * type UserPartialName = PartialByKeys<User, "name">;
  */
@@ -264,7 +264,7 @@ export type PartialByKeys<Obj extends object, Keys extends keyof Obj = keyof Obj
  *   lastname: string,
  *   age: number
  * };
- * 
+ *
  * // Expected: { age: number }
  * type UserExcludeStrings = OmitByType<User, string>;
  */
@@ -309,7 +309,7 @@ export type RetrieveKeyValue<Obj1 extends object, Obj2 extends object, Key> = Ke
  *   age?: number,
  *   address?: string
  * };
- * 
+ *
  * // Expected: { name: string, age?: number, address?: string }
  * type UserRequiredName = RequiredByKeys<User, "name">;
  */
@@ -335,7 +335,7 @@ type FilterImplementation<Array extends unknown[], Predicate, Build extends unkn
  * @example
  * // Expected: [2]
  * type Filter1 = Filter<[0, 1, 2], 2>
- * 
+ *
  * // Expected: [0, 1]
  * type Filter2 = Filter<[0, 1, 2], 0 | 1>
  */
@@ -353,7 +353,7 @@ export type Filter<Array extends unknown[], Predicate> = FilterImplementation<Ar
  * interface Bar {
  *   bar: number
  * };
- * 
+ *
  * // Expected: { bar: string | number }
  * type MergeFooBar = UnionMerge<Foo, Bar>;
  */
@@ -398,7 +398,7 @@ export type Mutable<Obj extends object> = {
  *     }
  *   }
  * };
- * 
+ *
  * // Expected: { foo: { bar: { foobar: number } } }
  * type NonReadonlyFoo = DeepMutable<Foo>;
  */
@@ -421,17 +421,17 @@ type MergeAllImplementation<Array extends readonly object[], Merge extends objec
  * interface Foo {
  *   foo: string
  * };
- * 
+ *
  * interface Bar {
  *   bar: string
  * };
- * 
+ *
  * interface FooBar {
  *   bar: number,
  *   foo: boolean,
  *   foobar: string
  * };
- * 
+ *
  * // Expected: { foo: string | boolean, bar: string | number, foobar: string }
  * type Merge = MergeAll<[Foo, Bar, FooBar]>;
  */
@@ -445,10 +445,10 @@ export type MergeAll<Array extends readonly object[]> = MergeAllImplementation<A
  * @example
  * // Expected: 1
  * type TupleNumber = ToUnion<1>;
- * 
+ *
  * // Expected: "foo"
  * type TupleString = ToUnion<"foo">;
- * 
+ *
  * // Expected: 1 | ["foo" | "bar"]
  * type TupleMultiple = ToUnion<1 | ["foo" | "bar"]>;
  */
@@ -468,7 +468,7 @@ type FilterOutImplementation<Array extends readonly unknown[], Predicate, Build 
  * @example
  * // Expected: [1, 2, 3]
  * type CleanNumbers = FilterOut<[1, 2, 3, 4, 5], [4, 5]>;
- * 
+ *
  * // Expected: ["bar", "foobar"]
  * type CleanStrings = FilterOut<["foo", "bar", "foobar"], "foo">;
  */
@@ -481,7 +481,7 @@ export type FilterOut<Array extends readonly unknown[], Predicate> = FilterOutIm
  * interface User {
  *   name: string
  * };
- * 
+ *
  * // Expected: { name: string, lastname: string }
  * type UserAppendLastname = AddPropertyToObject<User, "lastname", string>;
  */
@@ -496,10 +496,10 @@ export type AddPropertyToObject<Obj extends object, NewProp extends string, Type
  * @example
  * // Expected: [1, 2, 3, 4]
  * type ReverseNumbers = Reverse<[1, 2, 3, 4]>;
- * 
+ *
  * // Expected: ["a", "b", "c"]
  * type ReverseStrings = Reverse<["a", "b", "c"]>;
- * 
+ *
  * // Expected: [() => void, { foo: number }, "bar", 2, "foo", 1]
  * type ReverseArray = Reverse<[1, "foo", 2, "bar", { foo: number }, () => void]>;
  */
@@ -521,13 +521,13 @@ type IndexOfImplementation<Array extends unknown[], Match, Index extends unknown
  * @example
  * // Expected: -1
  * type IndexOf1 = IndexOf<[0, 0, 0], 2>;
- * 
+ *
  * // Expected: 2
  * type IndexOf2 = IndexOf<[string, 1, number, "a"], number>;
- * 
+ *
  * // Expected: 4
  * type IndexOf3 = IndexOf<[string, 1, number, "a", any], any>;
- * 
+ *
  * // Expected: 1
  * type IndexOf4 = IndexOf<[string, "a"], "a">;
  */
@@ -556,13 +556,13 @@ type LastIndexOfImplementation<
  * @example
  * // Expected: 3
  * type LastIndexOf1 = LastIndexOf<[1, 2, 3, 2, 1], 2> ;
- * 
+ *
  * // Expected: 7
  * type LastIndexOf2 = LastIndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3>;
- * 
+ *
  * // Expected: 4
  * type LastIndexOf3 = LastIndexOf<[string, 2, number, "a", number, 1], number>;
- * 
+ *
  * // Expected: 5
  * type LastIndexOf4 = LastIndexOf<[string, any, 1, number, "a", any, 1], any>;
  */
@@ -577,9 +577,9 @@ export type LastIndexOf<Array extends unknown[], Match> = LastIndexOfImplementat
  * @example
  * // Expected: ["-", "12", ""]
  * type Test1 = PercentageParser<"-12">;
- * 
+ *
  * // Expected: ["+", "89", "%"]
- * type Test2 = PercentageParser<"+89%">; 
+ * type Test2 = PercentageParser<"+89%">;
  */
 export type PercentageParser<
 	Percentage extends string,
@@ -614,7 +614,7 @@ type RepeatConstructTuple<
  * @example
  * // Expected: [unknown, unknown]
  * type TupleSize2 = ConstructTuple<2>;
- * 
+ *
  * // Expected: ["", ""]
  * type TupleSize3 = ConstructTuple<2, "">;
  */
@@ -639,7 +639,7 @@ type CheckRepeatedTupleImplementation<Array extends unknown[], Build extends unk
  * @example
  * // Expected: false
  * type TupleNumber1 = CheckRepeatedTuple<[1, 2, 3]>;
- * 
+ *
  * // Expected: true
  * type TupleNumber2 = CheckRepeatedTuple<[1, 2, 1]>;
  */
@@ -673,7 +673,7 @@ export type ObjectEntries<Obj extends object, RequiredObj extends object = Requi
  * @example
  * // Expected: true
  * type Test1 = AllEquals<[number, number, number], number>;
- * 
+ *
  * // Expected: true
  * type Test2 = AllEquals<[[1], [1], [1]], [1]>;
  */
@@ -693,7 +693,7 @@ export type AllEquals<Array extends unknown[], Comparator> = Array extends [infe
  *     bar: number,
  *     foobar: boolean
  * };
- * 
+ *
  * //Expected: { foo: number, bar: number, foobar: number }
  * type ReplaceStrings = ReplaceKeys<Foo, "foo" | "foobar", { foo: number, foobar: number }>;
  */
@@ -731,8 +731,8 @@ export type MapTypes<Obj extends object, Mapper extends { from: unknown; to: unk
  *
  * @example
  * // Expected: 3
- * type Truncated = Trunc<3.14>; 
- * 
+ * type Truncated = Trunc<3.14>;
+ *
  * // Expected: -2
  * type TruncatedNegative = Trunc<-2.99>;
  */

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -22,8 +22,10 @@ export type Prettify<Obj extends object> = {
  *     street: string,
  *     avenue: string
  *   }
- * }
- * type ReadonlyUser = DeepReadonly<User> // { readonly name: string,  address: { readonly street: string, readonly avenue } }
+ * };
+ * 
+ * // Expected: { readonly name: string, readonly address: { readonly street: string, readonly avenue: string } }
+ * type ReadonlyUser = DeepReadonly<User>;
  */
 export type DeepReadonly<Obj extends object> = {
 	readonly [Property in keyof Obj]: Obj[Property] extends Function
@@ -38,8 +40,8 @@ export type DeepReadonly<Obj extends object> = {
  * This is useful for representing a set of allowed values based on the array elements
  *
  * @example
- * type StringUnion = ["1", "2", "3"]
- * type Union = TypleToUnion<StringUnion> // "1" | "2" | "3"
+ * // Expected: "1" | "2" | "3"
+ * type Union = TypleToUnion<["1", "2", "3"]>;
  */
 export type TupleToUnion<Array extends readonly unknown[]> = Array extends [infer Item, ...infer Spread]
 	? Item | TupleToUnion<Spread>
@@ -50,7 +52,8 @@ export type TupleToUnion<Array extends readonly unknown[]> = Array extends [infe
  *
  * @example
  * const numbers: number[] = [1, 2, 3, 4, 5];
- * type SizeOfNumbers = Size<typeof numbers>; // SizeOfNumbers = 5
+ * // Expected: 5
+ * type SizeOfNumbers = Size<typeof numbers>; 
  */
 export type Size<Array extends unknown[]> = Array extends unknown[] ? Array["length"] : 0;
 
@@ -58,7 +61,8 @@ export type Size<Array extends unknown[]> = Array extends unknown[] ? Array["len
  * Gets the type of the last element in an array, or `never` if the array is empty.
  *
  * @example
- * type LastItem = Last<1, 2, 3, 4> // 4
+ * // Expected: 4
+ * type LastItem = Last<1, 2, 3, 4>;
  */
 export type Last<Array extends unknown[]> = Array extends [...any, infer Last] ? Last : never;
 
@@ -67,8 +71,11 @@ export type Last<Array extends unknown[]> = Array extends [...any, infer Last] ?
  * except the last. If the array is empty, returns an empty array type
  *
  * @example
- * type PopStr = Pop<["a", "b", "c"]> // ["a", "b"]
- * type PopNums = Pop<[1, 2, 3]> // [1, 2]
+ * // Expected: ["a", "b"]
+ * type PopStr = Pop<["a", "b", "c"]>;
+ * 
+ * // Expected: [1, 2]
+ * type PopNums = Pop<[1, 2, 3]>;
  */
 export type Pop<Array extends unknown[]> = Array extends [...infer Spread, unknown] ? Spread : [];
 
@@ -92,9 +99,11 @@ export type Awaited<T extends PromiseLike<unknown>> =
  *
  * @example
  * function add(x: number, y: number): number {
- *     return x + y;
- * }
- * type AddParams = Parameters<typeof add>; // AddParams = [number, number]
+ *   return x + y;
+ * };
+ * 
+ * // Expected: [number, number]
+ * type AddParams = Parameters<typeof add>;
  */
 export type Parameters<Function extends ArgsFunction> = Function extends (...args: infer Params) => void ? Params : never;
 
@@ -106,8 +115,10 @@ export type Parameters<Function extends ArgsFunction> = Function extends (...arg
  *   name: string
  *   lastname: string,
  *   age: number
- * }
- * type PickUser = Pick<User, "age"> // { age: number }
+ * };
+ * 
+ * // Expected: { age: number }
+ * type PickUser = Pick<User, "age">;
  */
 export type Pick<Obj extends object, Keys extends keyof Obj> = {
 	[Property in Keys]: Obj[Property];
@@ -117,9 +128,14 @@ export type Pick<Obj extends object, Keys extends keyof Obj> = {
  * Check if a value exists within a tuple and is equal to a specific value
  *
  * @example
- * type IncludesNumber = Includes<[1, 2, 3], 3> // true
- * type IncludesString = Includes<["foo", "bar", "foobar"], "bar"> // true
- * type NoIncludes = Includes<["foo", "bar", "foofoo"], "foobar"> // false
+ * // Expected: true
+ * type IncludesNumber = Includes<[1, 2, 3], 3>;
+ * 
+ * // Expected: true
+ * type IncludesString = Includes<["foo", "bar", "foobar"], "bar">;
+ * 
+ * // Expected: false
+ * type NoIncludes = Includes<["foo", "bar", "foofoo"], "foobar">;
  */
 export type Includes<Array extends unknown[], Match> = Array extends [infer Compare, ...infer Spread]
 	? Equals<Compare, Match> extends true
@@ -131,8 +147,8 @@ export type Includes<Array extends unknown[], Match> = Array extends [infer Comp
  * Creates a new type that omits properties from an object type based on another type
  *
  * @example
- * type Person = { name: string; age: number; email: string };
- * type NoEmailPerson = Omit<Person, "email">;  // NoEmailPerson = { name: string; age: number }
+ * // Expected: { name: string; age: number }
+ * type NoEmailPerson = Omit<{ name: string; age: number; email: string }, "email">;
  */
 export type Omit<Obj extends object, Keys extends keyof Obj> = {
 	[Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
@@ -144,13 +160,14 @@ export type Omit<Obj extends object, Keys extends keyof Obj> = {
  * @example
  * interface Foo {
  *   foo: string,
- * }
+ * };
  *
  * interface Bar {
  *   bar: number
- * }
+ * };
  *
- * type PropsFooBar = Properties<Foo, Bar> // "foo" | "bar"
+ * // Expected: "foo" | "bar"
+ * type PropsFooBar = Properties<Foo, Bar>;
  */
 export type Properties<Obj1 extends object, Obj2 extends object> = keyof Obj1 | keyof Obj2;
 
@@ -162,14 +179,15 @@ export type Properties<Obj1 extends object, Obj2 extends object> = keyof Obj1 | 
  * interface Config {
  *   storePaths: string[],
  *   hooks: unknown[]
- * }
+ * };
  *
  * interface AppStore {
  *   path: string,
  *   hooks: ArgsFunction[]
- * }
+ * };
  *
- * type MergeConfig = Merge<Config, AppStore> // { storePaths: string[], path: string, hooks: ArgsFunction[] }
+ * // Expected: { storePaths: string[], path: string, hooks: ArgsFunction[] }
+ * type MergeConfig = Merge<Config, AppStore>;
  */
 export type Merge<Obj1 extends object, Obj2 extends object> = {
 	[Property in Properties<Obj1, Obj2>]: RetrieveKeyValue<Obj2, Obj1, Property>;
@@ -179,18 +197,19 @@ export type Merge<Obj1 extends object, Obj2 extends object> = {
  * Create a new object based in the difference keys between the objects.
  *
  * @example
- * type Foo = {
- * 	name: string
- * 	age: string
- * }
+ * interface Foo {
+ *   name: string
+ *   age: string
+ * };
  *
- * type Bar = {
- * 	name: string
- * 	age: string
- * 	gender: number
- * }
- *
- * type DiffFoo = Intersection<Foo, Bar> // { gender: number }
+ * interface Bar {
+ *   name: string
+ *   age: string
+ *   gender: number
+ * };
+ * 
+ * // Expected: { gender: number }
+ * type DiffFoo = Intersection<Foo, Bar>;
  */
 export type Intersection<Obj1 extends object, Obj2 extends object> = {
 	[Property in Properties<Obj1, Obj2> as Property extends keyof Obj1 & keyof Obj2 ? never : Property]: RetrieveKeyValue<
@@ -205,11 +224,13 @@ export type Intersection<Obj1 extends object, Obj2 extends object> = {
  *
  * @example
  * interface User {
- * 	name: string,
- * 	lastname: string,
- * 	age: number
- * }
- * type UserStr = PickByType<User, string> // { name: string, lastname: string }
+ *   name: string,
+ *   lastname: string,
+ *   age: number
+ * };
+ * 
+ * // Expected: { name: string, lastname: string }
+ * type UserStr = PickByType<User, string>;
  */
 export type PickByType<Obj extends object, Type> = {
 	[Property in keyof Obj as Obj[Property] extends Type ? Property : never]: Obj[Property];
@@ -220,11 +241,13 @@ export type PickByType<Obj extends object, Type> = {
  *
  * @example
  * interface User {
- * 	name: string,
- * 	lastname: string,
- *	age: number
- * }
- * type UserPartialName = PartialByKeys<User, "name"> // { name?: string, lastname: string, age: number }
+ *   name: string,
+ *   lastname: string,
+ *   age: number
+ * };
+ * 
+ * // Expected: { name?: string, lastname: string, age: number }
+ * type UserPartialName = PartialByKeys<User, "name">;
  */
 export type PartialByKeys<Obj extends object, Keys extends keyof Obj = keyof Obj> = Prettify<
 	{
@@ -237,11 +260,13 @@ export type PartialByKeys<Obj extends object, Keys extends keyof Obj = keyof Obj
  *
  * @example
  * interface User {
- * 	name: string,
- * 	lastname: string,
- * 	age: number
- * }
- * type UserExcludeStrings = OmitByType<User, string> // { age: number }
+ *   name: string,
+ *   lastname: string,
+ *   age: number
+ * };
+ * 
+ * // Expected: { age: number }
+ * type UserExcludeStrings = OmitByType<User, string>;
  */
 export type OmitByType<Obj extends object, Type> = {
 	[Property in keyof Obj as Obj[Property] extends Type ? never : Property]: Obj[Property];
@@ -283,8 +308,10 @@ export type RetrieveKeyValue<Obj1 extends object, Obj2 extends object, Key> = Ke
  *   name?: string,
  *   age?: number,
  *   address?: string
- * }
- * type UserRequiredName = RequiredByKeys<User, "name"> // { name: string, age?: number, address?: string }
+ * };
+ * 
+ * // Expected: { name: string, age?: number, address?: string }
+ * type UserRequiredName = RequiredByKeys<User, "name">;
  */
 export type RequiredByKeys<Obj extends object, Keys extends keyof Obj = keyof Obj> = Prettify<
 	{
@@ -306,8 +333,11 @@ type FilterImplementation<Array extends unknown[], Predicate, Build extends unkn
  * generic type.
  *
  * @example
- * type Filter1 = Filter<[0, 1, 2], 2> // [2]
- * type Filter2 = Filter<[0, 1, 2], 0 | 1> // [0, 1]
+ * // Expected: [2]
+ * type Filter1 = Filter<[0, 1, 2], 2>
+ * 
+ * // Expected: [0, 1]
+ * type Filter2 = Filter<[0, 1, 2], 0 | 1>
  */
 export type Filter<Array extends unknown[], Predicate> = FilterImplementation<Array, Predicate, []>;
 
@@ -318,12 +348,14 @@ export type Filter<Array extends unknown[], Predicate> = FilterImplementation<Ar
  * @example
  * interface Foo {
  *   bar: string
- * }
+ * };
  *
  * interface Bar {
  *   bar: number
- * }
- * type MergeFooBar = UnionMerge<Foo, Bar> // { bar: string | number }
+ * };
+ * 
+ * // Expected: { bar: string | number }
+ * type MergeFooBar = UnionMerge<Foo, Bar>;
  */
 export type UnionMerge<Obj1 extends object, Obj2 extends object> = {
 	[Prop in Properties<Obj1, Obj2>]: Prop extends keyof Obj1
@@ -345,9 +377,10 @@ export type UnionMerge<Obj1 extends object, Obj2 extends object> = {
  *   readonly name: string;
  *   readonly lastname: string;
  *   readonly age: number;
- * }
+ * };
  *
- * type NonReadonlyUser = Mutable<User>; // { name: string, lastname: string, age: number }
+ * // Expected: { name: string, lastname: string, age: number }
+ * type NonReadonlyUser = Mutable<User>;
  */
 export type Mutable<Obj extends object> = {
 	-readonly [Property in keyof Obj]: Obj[Property];
@@ -364,8 +397,10 @@ export type Mutable<Obj extends object> = {
  *       readonly foobar: number
  *     }
  *   }
- * }
- * type NonReadonlyFoo = DeepMutable<Foo> // { foo: { bar: { foobar: number } } }
+ * };
+ * 
+ * // Expected: { foo: { bar: { foobar: number } } }
+ * type NonReadonlyFoo = DeepMutable<Foo>;
  */
 export type DeepMutable<Obj extends object> = {
 	-readonly [Property in keyof Obj]: Obj[Property] extends object ? DeepMutable<Obj[Property]> : Obj[Property];
@@ -385,17 +420,20 @@ type MergeAllImplementation<Array extends readonly object[], Merge extends objec
  * @example
  * interface Foo {
  *   foo: string
- * }
+ * };
+ * 
  * interface Bar {
  *   bar: string
- * }
+ * };
+ * 
  * interface FooBar {
  *   bar: number,
  *   foo: boolean,
  *   foobar: string
- * }
- * type Merge = MergeAll<[Foo, Bar, FooBar]>
- * // { foo: string | boolean, bar: string | number, foobar: string }
+ * };
+ * 
+ * // Expected: { foo: string | boolean, bar: string | number, foobar: string }
+ * type Merge = MergeAll<[Foo, Bar, FooBar]>;
  */
 export type MergeAll<Array extends readonly object[]> = MergeAllImplementation<Array, {}>;
 
@@ -405,9 +443,14 @@ export type MergeAll<Array extends readonly object[]> = MergeAllImplementation<A
  * receive whatever type
  *
  * @example
- * type TupleNumber = ToUnion<1> // 1
- * type TupleString = ToUnion<"foo"> // foo
- * type TupleMultiple = ToUnion<1 | ["foo" | "bar"]>
+ * // Expected: 1
+ * type TupleNumber = ToUnion<1>;
+ * 
+ * // Expected: "foo"
+ * type TupleString = ToUnion<"foo">;
+ * 
+ * // Expected: 1 | ["foo" | "bar"]
+ * type TupleMultiple = ToUnion<1 | ["foo" | "bar"]>;
  */
 export type ToUnion<T> = T extends [infer Item, ...infer Spread] ? Item | ToUnion<Spread> : T;
 
@@ -423,8 +466,11 @@ type FilterOutImplementation<Array extends readonly unknown[], Predicate, Build 
  * does not match with the predicated
  *
  * @example
- * type CleanNumbers = FilterOut<[1, 2, 3, 4, 5], [4, 5]> // [1, 2, 3]
- * type CleanStrings = FilterOut<["foo", "bar", "foobar"], "foo"> // ["bar", "foobar"]
+ * // Expected: [1, 2, 3]
+ * type CleanNumbers = FilterOut<[1, 2, 3, 4, 5], [4, 5]>;
+ * 
+ * // Expected: ["bar", "foobar"]
+ * type CleanStrings = FilterOut<["foo", "bar", "foobar"], "foo">;
  */
 export type FilterOut<Array extends readonly unknown[], Predicate> = FilterOutImplementation<Array, Predicate, []>;
 
@@ -434,8 +480,10 @@ export type FilterOut<Array extends readonly unknown[], Predicate> = FilterOutIm
  * @example
  * interface User {
  *   name: string
- * }
- * type UserAppendLastname = AddPropertyToObject<User, "lastname", string>
+ * };
+ * 
+ * // Expected: { name: string, lastname: string }
+ * type UserAppendLastname = AddPropertyToObject<User, "lastname", string>;
  */
 export type AddPropertyToObject<Obj extends object, NewProp extends string, TypeValue> = {
 	[Property in keyof Obj | NewProp]: Property extends keyof Obj ? Obj[Property] : TypeValue;
@@ -446,10 +494,14 @@ export type AddPropertyToObject<Obj extends object, NewProp extends string, Type
  * its order
  *
  * @example
- * type ReverseNumbers = Reverse<[1, 2, 3, 4]> // [1, 2, 3, 4]
- * type ReverseStrings = Reverse<["a", "b", "c"]> // ["a", "b", "c"]
- * type ReverseArray = Reverse<[1, "foo", 2, "bar", { foo: number }, () => void]>
- * // [() => void, { foo: number }, "bar", 2, "foo", 1]
+ * // Expected: [1, 2, 3, 4]
+ * type ReverseNumbers = Reverse<[1, 2, 3, 4]>;
+ * 
+ * // Expected: ["a", "b", "c"]
+ * type ReverseStrings = Reverse<["a", "b", "c"]>;
+ * 
+ * // Expected: [() => void, { foo: number }, "bar", 2, "foo", 1]
+ * type ReverseArray = Reverse<[1, "foo", 2, "bar", { foo: number }, () => void]>;
  */
 export type Reverse<Array extends unknown[]> = Array extends [infer Item, ...infer Spread] ? [...Reverse<Spread>, Item] : Array;
 
@@ -467,10 +519,17 @@ type IndexOfImplementation<Array extends unknown[], Match, Index extends unknown
  * If the element `Match` does not appear, it returns `-1`.
  *
  * @example
- * type IndexOf1 = IndexOf<[0, 0, 0], 2> // -1
- * type IndexOf2 = IndexOf<[string, 1, number, "a"], number> // 2
- * type IndexOf3 = IndexOf<[string, 1, number, "a", any], any> // 4
- * type IndexOf4 = IndexOf<[string, "a"], "a"> // 1
+ * // Expected: -1
+ * type IndexOf1 = IndexOf<[0, 0, 0], 2>;
+ * 
+ * // Expected: 2
+ * type IndexOf2 = IndexOf<[string, 1, number, "a"], number>;
+ * 
+ * // Expected: 4
+ * type IndexOf3 = IndexOf<[string, 1, number, "a", any], any>;
+ * 
+ * // Expected: 1
+ * type IndexOf4 = IndexOf<[string, "a"], "a">;
  */
 export type IndexOf<Array extends unknown[], Match> = IndexOfImplementation<Array, Match, []>;
 
@@ -495,10 +554,17 @@ type LastIndexOfImplementation<
  * If the element `Match` does not appear, it returns `-1`.
  *
  * @example
- * type LastIndexOf1 = LastIndexOf<[1, 2, 3, 2, 1], 2> // 3
- * type LastIndexOf2 = LastIndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3> // 7
- * type LastIndexOf3 = LastIndexOf<[string, 2, number, 'a', number, 1], number> // 4
- * type LastIndexOf4 = LastIndexOf<[string, any, 1, number, 'a', any, 1], any> // 5
+ * // Expected: 3
+ * type LastIndexOf1 = LastIndexOf<[1, 2, 3, 2, 1], 2> ;
+ * 
+ * // Expected: 7
+ * type LastIndexOf2 = LastIndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3>;
+ * 
+ * // Expected: 4
+ * type LastIndexOf3 = LastIndexOf<[string, 2, number, "a", number, 1], number>;
+ * 
+ * // Expected: 5
+ * type LastIndexOf4 = LastIndexOf<[string, any, 1, number, "a", any, 1], any>;
  */
 export type LastIndexOf<Array extends unknown[], Match> = LastIndexOfImplementation<Array, Match, [], []>;
 
@@ -509,8 +575,11 @@ export type LastIndexOf<Array extends unknown[], Match> = LastIndexOfImplementat
  * - `Unit` is the percentage symbol "%" or an empty string if no unit is present.
  *
  * @example
- * type Test1 = PercentageParser<"-12"> // ["-", "12", ""]
- * type Test2 = PercentageParser<"+89%"> // ["+", "89", "%"]
+ * // Expected: ["-", "12", ""]
+ * type Test1 = PercentageParser<"-12">;
+ * 
+ * // Expected: ["+", "89", "%"]
+ * type Test2 = PercentageParser<"+89%">; 
  */
 export type PercentageParser<
 	Percentage extends string,
@@ -543,8 +612,11 @@ type RepeatConstructTuple<
  * reate a tuple with a defined size, where each element is of a specified type
  *
  * @example
- * type TupleSize2 = ConstructTuple<2> // [unknown, unknown]
- * type TupleSize3 = ConstructTuple<2, ""> // ["", ""]
+ * // Expected: [unknown, unknown]
+ * type TupleSize2 = ConstructTuple<2>;
+ * 
+ * // Expected: ["", ""]
+ * type TupleSize3 = ConstructTuple<2, "">;
  */
 export type ConstructTuple<
 	Length extends number,
@@ -565,8 +637,11 @@ type CheckRepeatedTupleImplementation<Array extends unknown[], Build extends unk
  * Check if there are duplidated elements inside the tuple
  *
  * @example
- * type TupleNumber1 = CheckRepeatedTuple<[1, 2, 3]> // false
- * type TupleNumber2 = CheckRepeatedTuple<[1, 2, 1]> // true
+ * // Expected: false
+ * type TupleNumber1 = CheckRepeatedTuple<[1, 2, 3]>;
+ * 
+ * // Expected: true
+ * type TupleNumber2 = CheckRepeatedTuple<[1, 2, 1]>;
  */
 export type CheckRepeatedTuple<Tuple extends unknown[]> = CheckRepeatedTupleImplementation<Tuple>;
 
@@ -583,9 +658,10 @@ export type Absolute<Expression extends number | string | bigint> = DropChar<`${
  *   foo: string,
  *   bar: number,
  *   foobar?: boolean
- * }
+ * };
  *
- * type FooEntries = ObjectEntries<Foo> // ["foo", string] | ["bar", number] | ["foobar", boolean]
+ * // Expected: ["foo", string] | ["bar", number] | ["foobar", boolean]
+ * type FooEntries = ObjectEntries<Foo>;
  */
 export type ObjectEntries<Obj extends object, RequiredObj extends object = Required<Obj>> = {
 	[Property in keyof RequiredObj]: [Property, RequiredObj[Property] extends undefined ? undefined : RequiredObj[Property]];
@@ -595,8 +671,11 @@ export type ObjectEntries<Obj extends object, RequiredObj extends object = Requi
  * Returns true if all elements within the tuple are equal to `Comparator` otherwise, returns false
  *
  * @example
- * type Test1 = AllEquals<[number, number, number], number> // true
- * type Test2 = AllEquals<[[1], [1], [1]], [1]> // true
+ * // Expected: true
+ * type Test1 = AllEquals<[number, number, number], number>;
+ * 
+ * // Expected: true
+ * type Test2 = AllEquals<[[1], [1], [1]], [1]>;
  */
 export type AllEquals<Array extends unknown[], Comparator> = Array extends [infer Item, ...infer Spread]
 	? Equals<Item, Comparator> extends true
@@ -613,9 +692,10 @@ export type AllEquals<Array extends unknown[], Comparator> = Array extends [infe
  *     foo: string,
  *     bar: number,
  *     foobar: boolean
- * }
+ * };
+ * 
  * //Expected: { foo: number, bar: number, foobar: number }
- * type ReplaceStrings = ReplaceKeys<Foo, "foo" | "foobar", { foo: number, foobar: number }>
+ * type ReplaceStrings = ReplaceKeys<Foo, "foo" | "foobar", { foo: number, foobar: number }>;
  */
 export type ReplaceKeys<Obj extends object, Keys extends string, Replace extends object, Default = unknown> = {
 	[Property in keyof Obj]: Property extends Keys
@@ -631,10 +711,10 @@ export type ReplaceKeys<Obj extends object, Keys extends string, Replace extends
  *
  * @example
  * // Expected: { foo: string, bar: boolean }
- * type ReplaceTypesI = MapTypes<{ foo: string, bar: number }, { from: number, to: boolean }>
+ * type ReplaceTypesI = MapTypes<{ foo: string, bar: number }, { from: number, to: boolean }>;
  *
  * // Expected: { foo: number, bar: number  }
- * type ReplaceTypesII = MapTypes<{ foo: string, bar: string }, { from: string, bar: number }>
+ * type ReplaceTypesII = MapTypes<{ foo: string, bar: string }, { from: string, bar: number }>;
  */
 export type MapTypes<Obj extends object, Mapper extends { from: unknown; to: unknown }> = {
 	[Property in keyof Obj]: Obj[Property] extends Mapper["from"]
@@ -650,8 +730,11 @@ export type MapTypes<Obj extends object, Mapper extends { from: unknown; to: unk
  * Truncates a number to its integer part.
  *
  * @example
- * type Truncated = Trunc<3.14>; // 3
- * type TruncatedNegative = Trunc<-2.99>; // -2
+ * // Expected: 3
+ * type Truncated = Trunc<3.14>; 
+ * 
+ * // Expected: -2
+ * type TruncatedNegative = Trunc<-2.99>;
  */
 export type Trunc<Math extends string | number | bigint> = `${Math}` extends `.${number}`
 	? "0"
@@ -671,13 +754,13 @@ export type Trunc<Math extends string | number | bigint> = `${Math}` extends `.$
  *     street: string,
  *     avenue: string
  *   }
- * }
+ * };
  *
  * // Expected: { name: string, address: { street: string } }
- * type OmitAvenueUser = DeepOmit<User, "addresss.avenue">
+ * type OmitAvenueUser = DeepOmit<User, "addresss.avenue">;
  *
  * // Expected: { address: { street: string, avenue: string } }
- * type OmitNameUser = DeepOmit<User, "name">
+ * type OmitNameUser = DeepOmit<User, "name">;
  */
 export type DeepOmit<Obj extends object, Pattern extends string> = {
 	[Property in keyof Obj as Pattern extends `${string}.${string}`
@@ -719,10 +802,10 @@ type ZipImplementation<T, U, Build extends unknown[] = []> = T extends [infer It
  *
  * @example
  * // Expected: [[1, "a"], [2, "b"], [3, "c"]]
- * type Zip1 = Zip<[1, 2, 3], ["a", "b", "c"]>
+ * type Zip1 = Zip<[1, 2, 3], ["a", "b", "c"]>;
  *
  * // Expected: [[1, "a"], [2, "b"]]
- * type Zip2 = Zip<[1, 2, 3], ["a", "b"]>
+ * type Zip2 = Zip<[1, 2, 3], ["a", "b"]>;
  */
 export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = ZipImplementation<Array1, Array2>;
 
@@ -735,10 +818,10 @@ export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = ZipImpleme
  *   name: "Foo",
  *   lastname: "Bar",
  *   age: 30
- * }
+ * };
  *
  * // Expected: { name: string, lastname: string, age: number }
- * type UserPrimitive = ToPrimitive<User>
+ * type UserPrimitive = ToPrimitive<User>;
  */
 export type ToPrimitive<Obj extends object> = {
 	[Property in keyof Obj]: Obj[Property] extends object


### PR DESCRIPTION
## Description
This pull request introduces several changes to the examples of utility types and string mappers. It adds `// Expected` comments to illustrate the return values of the utility types or string mappers for given examples. The aim of these changes is to provide a clearer understanding of how the utility types work and what their expected outputs are.


## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->