### PR TITLE
feat: add `NumberRange` utility type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ export type {
 	Trunc,
 	Zip,
 	ToPrimitive,
+	NumberRange,
 } from "./utility-types.js";
 
 export type {

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -830,3 +830,43 @@ export type ToPrimitive<Obj extends object> = {
 			: ToPrimitive<Obj[Property]>
 		: ReturnTypeOf<Obj[Property]>;
 };
+
+/**
+ * Creates a series of numbers between the range of `Low` and `High`. This utility type
+ * is internally used by `NumberRange`.
+ *
+ * @link `NumberRange`
+ */
+type NumberRangeImplementation<
+	Low extends number,
+	High extends number,
+	Range extends unknown = never,
+	Index extends unknown[] = [],
+	LowRange extends boolean = false,
+> = Index["length"] extends Low
+	? NumberRangeImplementation<Low, High, Range | Index["length"], [...Index, 1], true>
+	: Index["length"] extends High
+		? Range | Index["length"]
+		: LowRange extends true
+			? NumberRangeImplementation<Low, High, Range | Index["length"], [...Index, 1], LowRange>
+			: NumberRangeImplementation<Low, High, Range, [...Index, 1], LowRange>;
+
+/**
+ * Creates a range of numbers that starts from `Low` and ends in `High`. The range is inclusive
+ * and the values should be positive numbers. If the `Low` or `High` values are negative numbers
+ * it returns `never`.
+ *
+ * @example
+ * // Expected: 1 | 2 | 3 | 4 | 5
+ * type Range1 = NumberRange<1, 5>;
+ *
+ * // Expected: never
+ * type Range2 = NumberRange<-1, 5>;
+ */
+export type NumberRange<Low extends number, High extends number> = `${Low}` extends `-${number}`
+	? never
+	: `${High}` extends `-${number}`
+		? never
+		: Low extends High
+			? Low
+			: NumberRangeImplementation<Low, High>;

--- a/testing/utility-type.test.ts
+++ b/testing/utility-type.test.ts
@@ -43,6 +43,7 @@ import type {
 	Chunk,
 	Zip,
 	ToPrimitive,
+	NumberRange,
 } from "../src/utility-types";
 
 describe("Readonly", () => {
@@ -564,5 +565,16 @@ describe("ToPrimitive", () => {
 			foo: { foobar: string; bar: boolean };
 			bar: number;
 		}>();
+	});
+});
+
+describe("NumberRange", () => {
+	test("Create a union type with a range of numbers", () => {
+		expectTypeOf<NumberRange<1, 5>>().toEqualTypeOf<1 | 2 | 3 | 4 | 5>();
+		expectTypeOf<NumberRange<9, 14>>().toEqualTypeOf<9 | 10 | 11 | 12 | 13 | 14>();
+		expectTypeOf<NumberRange<-5, 5>>().toEqualTypeOf<never>();
+		expectTypeOf<NumberRange<0, 0>>().toEqualTypeOf<0>();
+		expectTypeOf<NumberRange<-5, -5>>().toEqualTypeOf<never>();
+		expectTypeOf<NumberRange<-5, 0>>().toEqualTypeOf<never>();
 	});
 });


### PR DESCRIPTION
## Description
This pull request introduces a new utility type called `NumberRange`, which creates a union type representing a range of numbers between a specified `Low` and `High` value. The resulting numbers are in ascending order and inclusive of both the `Low` and `High` values. If the provided range contains negative numbers, the type will return  `never`.



## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->