### PR TITLE
chore(docs): improve utility types examples

### DIFF
--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -109,6 +109,7 @@ type DropCharImplementation<
  * @example
  * // Expected: butterfly!
  * type Test1 = DropChar<"butter fly!", "">
+ *
  * // Expected: "butterfly!"
  * type Test2 = DropChar<" b u t t e r f l y ! ", " ">
  */

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,9 +1,23 @@
 /**
  * Checks if two values are strictly equal, regardless of their distribution within conditional types
+ *
+ * @example
+ * // Expected: true
+ * type CheckTrue = Equals<true, true>;
+ *
+ * // Expected: false
+ * type CheckTrue = Equals<() => {}, true>;
  */
 export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
 
 /**
  * Ensures that the parameter is true.
+ *
+ * @example
+ * // Expected: true
+ * type CheckTrue = Expect<true>;
+ *
+ * // Expected: false
+ * type CheckFalse = Expect<false>;
  */
 export type Expect<T extends true> = T;

--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -2,9 +2,13 @@ import type { Odd } from "./types";
 
 /**
  * Check if the parameter is a never value
+ *
  * @example
- * type CheckNever = IsNever<never> // true
- * type CheckStr = IsNever<string> // false
+ * // Expected: true
+ * type CheckNever = IsNever<never>;
+ *
+ * // Expected: false
+ * type CheckStr = IsNever<string>;
  */
 export type IsNever<T> = [T] extends [never] ? true : false;
 
@@ -12,7 +16,10 @@ export type IsNever<T> = [T] extends [never] ? true : false;
  * Check if the number provided is odd or not
  *
  * @example
- * type CheckOdd = IsOdd<2023> // true
- * type CheckEven = IsOdd<2024> // false
+ * // Expected: true
+ * type CheckOdd = IsOdd<2023>
+ *
+ * // Expected: false
+ * type CheckEven = IsOdd<2024>
  */
 export type IsOdd<T extends number> = `${T}` extends `${string}${Odd}` ? true : false;

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,8 @@
  *
  * @example
  * function getPointsAsync(callback: ArgsFunction) {
- *  // do anything here
- *  callback((x: number, y: number, z: number) => {})
+ *   // do anything here
+ *   callback((x: number, y: number, z: number) => {})
  * }
  */
 export type ArgsFunction = (...args: any) => void;
@@ -21,7 +21,6 @@ export type Nullish = null | undefined;
 /**
  * Represents a primitive data type that can also be null or undefined.
  * This type is useful for situations where nullish values are allowed.
- *
  */
 export type PrimitiveNullish = number | string | boolean | bigint | symbol | Nullish;
 


### PR DESCRIPTION
## Description
This pull request introduces several changes to the examples documentation for utility types. The focus is on the `test` and `type-guards` TypeScript files. It also fixes line spacing issues in some examples.
## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->