### PR TITLE
chore: clean up test files

### DIFF
--- a/test/array-types.test.ts
+++ b/test/array-types.test.ts
@@ -1,0 +1,138 @@
+import { describe, test, expectTypeOf } from "vitest";
+import type * as utilities from "../src/array-types";
+
+describe("TupleToUnion", () => {
+	test("Create union type", () => {
+		expectTypeOf<utilities.TupleToUnion<["foo", "bar"]>>().toEqualTypeOf<"foo" | "bar">();
+		expectTypeOf<utilities.TupleToUnion<[1, 2]>>().toEqualTypeOf<1 | 2>();
+		expectTypeOf<utilities.TupleToUnion<["foo", 1, "bar", 2]>>().toEqualTypeOf<"foo" | "bar" | 1 | 2>();
+	});
+});
+
+describe("Tuple methods", () => {
+	describe("Last", () => {
+		test("Retrieve the last element of a tuple", () => {
+			expectTypeOf<utilities.Last<[]>>().toEqualTypeOf<never>();
+			expectTypeOf<utilities.Last<[1, 2, 3]>>().toEqualTypeOf<3>();
+			expectTypeOf<utilities.Last<["foo", "bar", "foobar"]>>().toEqualTypeOf<"foobar">();
+		});
+	});
+
+	describe("Pop", () => {
+		test("Remove the last element of a tuple", () => {
+			expectTypeOf<utilities.Pop<[]>>().toEqualTypeOf<[]>();
+			expectTypeOf<utilities.Pop<[1, 2, 3]>>().toEqualTypeOf<[1, 2]>();
+			expectTypeOf<utilities.Pop<["foo", "bar", "foobar"]>>().toEqualTypeOf<["foo", "bar"]>();
+		});
+	});
+
+	describe("Size", () => {
+		test("Returns the size of the tuple", () => {
+			expectTypeOf<utilities.Size<[]>>().toEqualTypeOf<0>();
+			expectTypeOf<utilities.Size<[1, 2, 3]>>().toEqualTypeOf<3>();
+			expectTypeOf<utilities.Size<["foo", "bar", "foobar", 1, 2, never, () => void, { foo: string }]>>().toEqualTypeOf<8>();
+		});
+	});
+
+	describe("Filter", () => {
+		test("Filter the elements based in the predicate", () => {
+			expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0>>().toEqualTypeOf<[0]>();
+			expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0 | 4>>().toEqualTypeOf<[0, 4]>();
+			expectTypeOf<utilities.Filter<[0, 0, 1, 1, 1], 1>>().toEqualTypeOf<[1, 1, 1]>();
+			expectTypeOf<utilities.Filter<["foo", "bar", "foobar"], "bar">>().toEqualTypeOf<["bar"]>();
+		});
+	});
+
+	describe("FilterOut", () => {
+		test("Removes the elements present in the predicate", () => {
+			expectTypeOf<utilities.FilterOut<[1, 2, 3, 4, 5], [4, 5]>>().toEqualTypeOf<[1, 2, 3]>();
+			expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar"], "foo">>().toEqualTypeOf<["bar", "foobar"]>();
+			expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar", 1, 2], "foo" | 2>>().toEqualTypeOf<["bar", "foobar", 1]>();
+			expectTypeOf<
+				utilities.FilterOut<[{ foo: string }, { bar: number }, { foobar: boolean }], { bar: number }>
+			>().toEqualTypeOf<[{ foo: string }, { foobar: boolean }]>();
+			expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar", 1, 2, { foo: string }], { foo: string }>>().toEqualTypeOf<
+				["foo", "bar", "foobar", 1, 2]
+			>();
+		});
+	});
+
+	describe("Reverse", () => {
+		test("Reverse the elements of a tuple type", () => {
+			expectTypeOf<utilities.Reverse<[1, 2, 3, 4]>>().toEqualTypeOf<[4, 3, 2, 1]>();
+			expectTypeOf<utilities.Reverse<["a", "b", "c"]>>().toEqualTypeOf<["c", "b", "a"]>();
+			expectTypeOf<utilities.Reverse<[1, "foo", 2, "bar", { foo: number }, () => void]>>().toEqualTypeOf<
+				[() => void, { foo: number }, "bar", 2, "foo", 1]
+			>();
+		});
+	});
+
+	describe("IndexOf", () => {
+		test("Get first index of an element", () => {
+			expectTypeOf<utilities.IndexOf<[0, 0, 0], 2>>().toEqualTypeOf<-1>();
+			expectTypeOf<utilities.IndexOf<[string, 1, number, "a"], number>>().toEqualTypeOf<2>();
+			expectTypeOf<utilities.IndexOf<[string, 1, number, "a", any], any>>().toEqualTypeOf<4>();
+			expectTypeOf<utilities.IndexOf<[string, "a"], "a">>().toEqualTypeOf<1>();
+		});
+
+		test("Get last index of an element", () => {
+			expectTypeOf<utilities.LastIndexOf<[1, 2, 3, 2, 1], 2>>().toEqualTypeOf<3>();
+			expectTypeOf<utilities.LastIndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3>>().toEqualTypeOf<7>();
+			expectTypeOf<utilities.LastIndexOf<[string, 2, number, "a", number, 1], number>>().toEqualTypeOf<4>();
+			expectTypeOf<utilities.LastIndexOf<[string, any, 1, number, "a", any, 1], any>>().toEqualTypeOf<5>();
+		});
+	});
+});
+
+describe("ConstructTuple", () => {
+	test("Create a tuple with a defined size", () => {
+		expectTypeOf<utilities.ConstructTuple<2>>().toEqualTypeOf<[unknown, unknown]>();
+		expectTypeOf<utilities.ConstructTuple<2, string>>().toEqualTypeOf<[string, string]>();
+		expectTypeOf<utilities.ConstructTuple<5, any>>().toEqualTypeOf<[any, any, any, any, any]>();
+	});
+});
+
+describe("CheckRepeatedTuple", () => {
+	test("Check if there are duplicated elements", () => {
+		expectTypeOf<utilities.CheckRepeatedTuple<[]>>().toEqualTypeOf<false>();
+		expectTypeOf<utilities.CheckRepeatedTuple<[1, 2, 1]>>().toEqualTypeOf<true>();
+		expectTypeOf<utilities.CheckRepeatedTuple<["foo", "bar", 1, 5]>>().toEqualTypeOf<false>();
+		expectTypeOf<utilities.CheckRepeatedTuple<[() => void, () => void]>>().toEqualTypeOf<true>();
+		expectTypeOf<utilities.CheckRepeatedTuple<[{ foo: string }, { foo: string }]>>().toEqualTypeOf<true>();
+	});
+});
+
+describe("AllEquals", () => {
+	test("Check if all elements are equal", () => {
+		expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 1>>().toEqualTypeOf<false>();
+		expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 0>>().toEqualTypeOf<true>();
+		expectTypeOf<utilities.AllEquals<[0, 0, 1, 0], 1>>().toEqualTypeOf<false>();
+		expectTypeOf<utilities.AllEquals<[number, number, number, number], number>>().toEqualTypeOf<true>();
+		expectTypeOf<utilities.AllEquals<[[1], [1], [1]], [1]>>().toEqualTypeOf<true>();
+		expectTypeOf<utilities.AllEquals<[{}, {}, {}], {}>>().toEqualTypeOf<true>();
+		expectTypeOf<utilities.AllEquals<[1, 1, 2], 1 | 2>>().toEqualTypeOf<false>();
+	});
+});
+
+describe("Chunk", () => {
+	test("Split an array into chunks", () => {
+		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 1>>().toEqualTypeOf<[[1], [2], [3], [4], [5]]>();
+		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 2>>().toEqualTypeOf<[[1, 2], [3, 4], [5]]>();
+		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 3>>().toEqualTypeOf<[[1, 2, 3], [4, 5]]>();
+		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 4>>().toEqualTypeOf<[[1, 2, 3, 4], [5]]>();
+		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 5>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
+		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 6>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
+		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], -2>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
+	});
+});
+
+describe("Zip", () => {
+	test("Zip two arrays into a tuple", () => {
+		expectTypeOf<utilities.Zip<[], []>>().toEqualTypeOf<[]>();
+		expectTypeOf<utilities.Zip<[1, 2, 3], ["foo"]>>().toEqualTypeOf<[[1, "foo"]]>();
+		expectTypeOf<utilities.Zip<[1, "bar", 3], ["foo", 2]>>().toEqualTypeOf<[[1, "foo"], ["bar", 2]]>();
+		expectTypeOf<utilities.Zip<[{ foo: string }, { bar: string }], ["foo", "bar"]>>().toEqualTypeOf<
+			[[{ foo: string }, "foo"], [{ bar: string }, "bar"]]
+		>();
+	});
+});

--- a/test/utility-type.test.ts
+++ b/test/utility-type.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expectTypeOf } from "vitest";
-import type * as utilities from "../src/utility-types";
+//import type * as utilities from "../src/utility-types";
+import type * as utilities from "../src/object-types";
 
 describe("Readonly", () => {
 	test("DeepReadonly for objects", () => {
@@ -15,14 +16,6 @@ describe("Readonly", () => {
 			readonly foo: { readonly bar: string };
 			readonly bar: { readonly foo: number };
 		}>();
-	});
-});
-
-describe("TupleToUnion", () => {
-	test("Create union type", () => {
-		expectTypeOf<utilities.TupleToUnion<["foo", "bar"]>>().toEqualTypeOf<"foo" | "bar">();
-		expectTypeOf<utilities.TupleToUnion<[1, 2]>>().toEqualTypeOf<1 | 2>();
-		expectTypeOf<utilities.TupleToUnion<["foo", 1, "bar", 2]>>().toEqualTypeOf<"foo" | "bar" | 1 | 2>();
 	});
 });
 
@@ -216,90 +209,6 @@ describe("Intersection", () => {
 	});
 });
 
-describe("Tuple methods", () => {
-	describe("Last", () => {
-		test("Retrieve the last element of a tuple", () => {
-			expectTypeOf<utilities.Last<[]>>().toEqualTypeOf<never>();
-			expectTypeOf<utilities.Last<[1, 2, 3]>>().toEqualTypeOf<3>();
-			expectTypeOf<utilities.Last<["foo", "bar", "foobar"]>>().toEqualTypeOf<"foobar">();
-		});
-	});
-
-	describe("Pop", () => {
-		test("Remove the last element of a tuple", () => {
-			expectTypeOf<utilities.Pop<[]>>().toEqualTypeOf<[]>();
-			expectTypeOf<utilities.Pop<[1, 2, 3]>>().toEqualTypeOf<[1, 2]>();
-			expectTypeOf<utilities.Pop<["foo", "bar", "foobar"]>>().toEqualTypeOf<["foo", "bar"]>();
-		});
-	});
-
-	describe("Size", () => {
-		test("Returns the size of the tuple", () => {
-			expectTypeOf<utilities.Size<[]>>().toEqualTypeOf<0>();
-			expectTypeOf<utilities.Size<[1, 2, 3]>>().toEqualTypeOf<3>();
-			expectTypeOf<utilities.Size<["foo", "bar", "foobar", 1, 2, never, () => void, { foo: string }]>>().toEqualTypeOf<8>();
-		});
-	});
-
-	describe("Filter", () => {
-		test("Filter the elements based in the predicate", () => {
-			expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0>>().toEqualTypeOf<[0]>();
-			expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0 | 4>>().toEqualTypeOf<[0, 4]>();
-			expectTypeOf<utilities.Filter<[0, 0, 1, 1, 1], 1>>().toEqualTypeOf<[1, 1, 1]>();
-			expectTypeOf<utilities.Filter<["foo", "bar", "foobar"], "bar">>().toEqualTypeOf<["bar"]>();
-		});
-	});
-
-	describe("FilterOut", () => {
-		test("Removes the elements present in the predicate", () => {
-			expectTypeOf<utilities.FilterOut<[1, 2, 3, 4, 5], [4, 5]>>().toEqualTypeOf<[1, 2, 3]>();
-			expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar"], "foo">>().toEqualTypeOf<["bar", "foobar"]>();
-			expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar", 1, 2], "foo" | 2>>().toEqualTypeOf<["bar", "foobar", 1]>();
-			expectTypeOf<
-				utilities.FilterOut<[{ foo: string }, { bar: number }, { foobar: boolean }], { bar: number }>
-			>().toEqualTypeOf<[{ foo: string }, { foobar: boolean }]>();
-			expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar", 1, 2, { foo: string }], { foo: string }>>().toEqualTypeOf<
-				["foo", "bar", "foobar", 1, 2]
-			>();
-		});
-	});
-
-	describe("Reverse", () => {
-		test("Reverse the elements of a tuple type", () => {
-			expectTypeOf<utilities.Reverse<[1, 2, 3, 4]>>().toEqualTypeOf<[4, 3, 2, 1]>();
-			expectTypeOf<utilities.Reverse<["a", "b", "c"]>>().toEqualTypeOf<["c", "b", "a"]>();
-			expectTypeOf<utilities.Reverse<[1, "foo", 2, "bar", { foo: number }, () => void]>>().toEqualTypeOf<
-				[() => void, { foo: number }, "bar", 2, "foo", 1]
-			>();
-		});
-	});
-
-	describe("IndexOf", () => {
-		test("Get first index of an element", () => {
-			expectTypeOf<utilities.IndexOf<[0, 0, 0], 2>>().toEqualTypeOf<-1>();
-			expectTypeOf<utilities.IndexOf<[string, 1, number, "a"], number>>().toEqualTypeOf<2>();
-			expectTypeOf<utilities.IndexOf<[string, 1, number, "a", any], any>>().toEqualTypeOf<4>();
-			expectTypeOf<utilities.IndexOf<[string, "a"], "a">>().toEqualTypeOf<1>();
-		});
-
-		test("Get last index of an element", () => {
-			expectTypeOf<utilities.LastIndexOf<[1, 2, 3, 2, 1], 2>>().toEqualTypeOf<3>();
-			expectTypeOf<utilities.LastIndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3>>().toEqualTypeOf<7>();
-			expectTypeOf<utilities.LastIndexOf<[string, 2, number, "a", number, 1], number>>().toEqualTypeOf<4>();
-			expectTypeOf<utilities.LastIndexOf<[string, any, 1, number, "a", any, 1], any>>().toEqualTypeOf<5>();
-		});
-	});
-});
-
-describe("PercentageParser", () => {
-	test("Parses a percentage string into a tuple", () => {
-		expectTypeOf<utilities.PercentageParser<"foobar">>().toEqualTypeOf<never>();
-		expectTypeOf<utilities.PercentageParser<"2024">>().toEqualTypeOf<["", "2024", ""]>();
-		expectTypeOf<utilities.PercentageParser<"-89">>().toEqualTypeOf<["-", "89", ""]>();
-		expectTypeOf<utilities.PercentageParser<"+89%">>().toEqualTypeOf<["+", "89", "%"]>();
-	});
-});
-
 describe("Omit Properties", () => {
 	describe("Omit", () => {
 		test("Omit the properties based on the key type", () => {
@@ -355,33 +264,6 @@ describe("Includes", () => {
 	});
 });
 
-describe("ConstructTuple", () => {
-	test("Create a tuple with a defined size", () => {
-		expectTypeOf<utilities.ConstructTuple<2>>().toEqualTypeOf<[unknown, unknown]>();
-		expectTypeOf<utilities.ConstructTuple<2, string>>().toEqualTypeOf<[string, string]>();
-		expectTypeOf<utilities.ConstructTuple<5, any>>().toEqualTypeOf<[any, any, any, any, any]>();
-	});
-});
-
-describe("CheckRepeatedTuple", () => {
-	test("Check if there are duplicated elements", () => {
-		expectTypeOf<utilities.CheckRepeatedTuple<[]>>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.CheckRepeatedTuple<[1, 2, 1]>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.CheckRepeatedTuple<["foo", "bar", 1, 5]>>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.CheckRepeatedTuple<[() => void, () => void]>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.CheckRepeatedTuple<[{ foo: string }, { foo: string }]>>().toEqualTypeOf<true>();
-	});
-});
-
-describe("Absolute", () => {
-	test("Returns the absolute version of a number", () => {
-		expectTypeOf<utilities.Absolute<-100>>().toEqualTypeOf<"100">();
-		expectTypeOf<utilities.Absolute<-0>>().toEqualTypeOf<"0">();
-		expectTypeOf<utilities.Absolute<-999_999_999_999>>().toEqualTypeOf<"999999999999">();
-		expectTypeOf<utilities.Absolute<-999_999_999_999_999n>>().toEqualTypeOf<"999999999999999">();
-	});
-});
-
 describe("ObjectEntries", () => {
 	test("Returns the entries from an object", () => {
 		expectTypeOf<utilities.ObjectEntries<{ foo: string }>>().toEqualTypeOf<["foo", string]>();
@@ -392,18 +274,6 @@ describe("ObjectEntries", () => {
 		expectTypeOf<utilities.ObjectEntries<{ foo?: undefined; bar: undefined | string }>>().toEqualTypeOf<
 			["foo", undefined] | ["bar", undefined | string]
 		>();
-	});
-});
-
-describe("AllEquals", () => {
-	test("Check if all elements are equal", () => {
-		expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 1>>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 0>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.AllEquals<[0, 0, 1, 0], 1>>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.AllEquals<[number, number, number, number], number>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.AllEquals<[[1], [1], [1]], [1]>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.AllEquals<[{}, {}, {}], {}>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.AllEquals<[1, 1, 2], 1 | 2>>().toEqualTypeOf<false>();
 	});
 });
 
@@ -481,18 +351,6 @@ describe("MapTypes", () => {
 	});
 });
 
-describe("Trunc", () => {
-	test("Truncate a number to its integer part", () => {
-		expectTypeOf<utilities.Trunc<3.14159>>().toEqualTypeOf<"3">();
-		expectTypeOf<utilities.Trunc<-3.14159>>().toEqualTypeOf<"-3">();
-		expectTypeOf<utilities.Trunc<42.1>>().toEqualTypeOf<"42">();
-		expectTypeOf<utilities.Trunc<0>>().toEqualTypeOf<"0">();
-		expectTypeOf<utilities.Trunc<1289n>>().toEqualTypeOf<"1289">();
-		expectTypeOf<utilities.Trunc<-0.98>>().toEqualTypeOf<"0">();
-		expectTypeOf<utilities.Trunc<-90000.98>>().toEqualTypeOf<"-90000">();
-	});
-});
-
 describe("DeepOmit", () => {
 	test("Omit properties from nested objects", () => {
 		expectTypeOf<utilities.DeepOmit<{ foo: string; bar: { foobar: number } }, "foo">>().toEqualTypeOf<{
@@ -515,29 +373,6 @@ describe("DeepOmit", () => {
 	});
 });
 
-describe("Chunk", () => {
-	test("Split an array into chunks", () => {
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 1>>().toEqualTypeOf<[[1], [2], [3], [4], [5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 2>>().toEqualTypeOf<[[1, 2], [3, 4], [5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 3>>().toEqualTypeOf<[[1, 2, 3], [4, 5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 4>>().toEqualTypeOf<[[1, 2, 3, 4], [5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 5>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 6>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], -2>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
-	});
-});
-
-describe("Zip", () => {
-	test("Zip two arrays into a tuple", () => {
-		expectTypeOf<utilities.Zip<[], []>>().toEqualTypeOf<[]>();
-		expectTypeOf<utilities.Zip<[1, 2, 3], ["foo"]>>().toEqualTypeOf<[[1, "foo"]]>();
-		expectTypeOf<utilities.Zip<[1, "bar", 3], ["foo", 2]>>().toEqualTypeOf<[[1, "foo"], ["bar", 2]]>();
-		expectTypeOf<utilities.Zip<[{ foo: string }, { bar: string }], ["foo", "bar"]>>().toEqualTypeOf<
-			[[{ foo: string }, "foo"], [{ bar: string }, "bar"]]
-		>();
-	});
-});
-
 describe("ToPrimitive", () => {
 	test("Converts a string to a primitive type", () => {
 		expectTypeOf<utilities.ToPrimitive<{ foo: string; bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
@@ -547,16 +382,5 @@ describe("ToPrimitive", () => {
 			foo: { foobar: string; bar: boolean };
 			bar: number;
 		}>();
-	});
-});
-
-describe("NumberRange", () => {
-	test("Create a union type with a range of numbers", () => {
-		expectTypeOf<utilities.NumberRange<1, 5>>().toEqualTypeOf<1 | 2 | 3 | 4 | 5>();
-		expectTypeOf<utilities.NumberRange<9, 14>>().toEqualTypeOf<9 | 10 | 11 | 12 | 13 | 14>();
-		expectTypeOf<utilities.NumberRange<-5, 5>>().toEqualTypeOf<never>();
-		expectTypeOf<utilities.NumberRange<0, 0>>().toEqualTypeOf<0>();
-		expectTypeOf<utilities.NumberRange<-5, -5>>().toEqualTypeOf<never>();
-		expectTypeOf<utilities.NumberRange<-5, 0>>().toEqualTypeOf<never>();
 	});
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,0 +1,43 @@
+import { describe, test, expectTypeOf } from "vitest";
+import type * as utilities from "../src/utils";
+
+describe("PercentageParser", () => {
+	test("Parses a percentage string into a tuple", () => {
+		expectTypeOf<utilities.PercentageParser<"foobar">>().toEqualTypeOf<never>();
+		expectTypeOf<utilities.PercentageParser<"2024">>().toEqualTypeOf<["", "2024", ""]>();
+		expectTypeOf<utilities.PercentageParser<"-89">>().toEqualTypeOf<["-", "89", ""]>();
+		expectTypeOf<utilities.PercentageParser<"+89%">>().toEqualTypeOf<["+", "89", "%"]>();
+	});
+});
+
+describe("Absolute", () => {
+	test("Returns the absolute version of a number", () => {
+		expectTypeOf<utilities.Absolute<-100>>().toEqualTypeOf<"100">();
+		expectTypeOf<utilities.Absolute<-0>>().toEqualTypeOf<"0">();
+		expectTypeOf<utilities.Absolute<-999_999_999_999>>().toEqualTypeOf<"999999999999">();
+		expectTypeOf<utilities.Absolute<-999_999_999_999_999n>>().toEqualTypeOf<"999999999999999">();
+	});
+});
+
+describe("Trunc", () => {
+	test("Truncate a number to its integer part", () => {
+		expectTypeOf<utilities.Trunc<3.14159>>().toEqualTypeOf<"3">();
+		expectTypeOf<utilities.Trunc<-3.14159>>().toEqualTypeOf<"-3">();
+		expectTypeOf<utilities.Trunc<42.1>>().toEqualTypeOf<"42">();
+		expectTypeOf<utilities.Trunc<0>>().toEqualTypeOf<"0">();
+		expectTypeOf<utilities.Trunc<1289n>>().toEqualTypeOf<"1289">();
+		expectTypeOf<utilities.Trunc<-0.98>>().toEqualTypeOf<"0">();
+		expectTypeOf<utilities.Trunc<-90000.98>>().toEqualTypeOf<"-90000">();
+	});
+});
+
+describe("NumberRange", () => {
+	test("Create a union type with a range of numbers", () => {
+		expectTypeOf<utilities.NumberRange<1, 5>>().toEqualTypeOf<1 | 2 | 3 | 4 | 5>();
+		expectTypeOf<utilities.NumberRange<9, 14>>().toEqualTypeOf<9 | 10 | 11 | 12 | 13 | 14>();
+		expectTypeOf<utilities.NumberRange<-5, 5>>().toEqualTypeOf<never>();
+		expectTypeOf<utilities.NumberRange<0, 0>>().toEqualTypeOf<0>();
+		expectTypeOf<utilities.NumberRange<-5, -5>>().toEqualTypeOf<never>();
+		expectTypeOf<utilities.NumberRange<-5, 0>>().toEqualTypeOf<never>();
+	});
+});


### PR DESCRIPTION
## Description
This pull request cleans up the test files for the utility types that were originally in the `utility-types.ts` file to reduce the load and improve the responsibility of the test files. Two new test files have been created: `array-types.test.t`s and `utils.test.ts`. The utilities that work with objects remain in the `utility-types.ts` file.


## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->