### PR TITLE
feat: add `FlattenArrayType` utility type

### DIFF
--- a/src/array-types.ts
+++ b/src/array-types.ts
@@ -259,3 +259,15 @@ type ZipImplementation<T, U, Build extends unknown[] = []> = T extends [infer It
  * type Zip2 = Zip<[1, 2, 3], ["a", "b"]>;
  */
 export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = ZipImplementation<Array1, Array2>;
+
+/**
+ * Returns the flatten type of an array.
+ *
+ * @example
+ * // Expected: number
+ * type Flatten1 = FlattenArrayType<number[][]>;
+ *
+ * // Expected: string
+ * type Flatten2 = FlattenArrayType<string[][][]>;
+ */
+export type FlattenArrayType<Array> = Array extends (infer Type)[] ? FlattenArrayType<Type> : Array;

--- a/test/array-types.test.ts
+++ b/test/array-types.test.ts
@@ -136,3 +136,13 @@ describe("Zip", () => {
 		>();
 	});
 });
+
+describe("FlattenArrayType", () => {
+	test("Flatten an array type", () => {
+		expectTypeOf<utilities.FlattenArrayType<number[]>>().toEqualTypeOf<number>();
+		expectTypeOf<utilities.FlattenArrayType<number[][]>>().toEqualTypeOf<number>();
+		expectTypeOf<utilities.FlattenArrayType<number[][][]>>().toEqualTypeOf<number>();
+		expectTypeOf<utilities.FlattenArrayType<string[][][][]>>().toEqualTypeOf<string>();
+		expectTypeOf<utilities.FlattenArrayType<unknown[][][][]>>().toEqualTypeOf<unknown>();
+	});
+});


### PR DESCRIPTION
## Description
This pull request introduces a new utility type called `FlattenArrayType`, which returns the flattened type of an array. It can be useful if the user wants to determine the base type of an array.


## Checklist
- [x]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [x]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->