### PR TITLE
chore: clean up the codebase

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,8 +1,6 @@
-# Build
+# build
 node_modules
 dist
 
-# Configurations
-package.json
+# files
 package-lock.json
-tsconfig.json

--- a/package.json
+++ b/package.json
@@ -3,14 +3,12 @@
   "version": "0.10.0",
   "description": "Utility types tools to enhances the productivity using typescript",
   "type": "module",
-  "main": "dist/index.d.ts",
   "scripts": {
     "dev": "tsup --watch",
     "test:watch": "vitest",
     "test": "vitest --run",
-    "build:js": "tsup src/validate-types.ts --format cjs,esm --dts --minify --outDir dist/utils",
-    "build": "tsup && npm run build:js",
-    "publish": "tsc",
+    "build": "tsup",
+    "publish": "npm run build",
     "format": "prettier --write .",
     "format:check": "prettier --check ."
   },
@@ -65,7 +63,9 @@
     "overrides": [
       {
         "files": [
-          ".github/**/*.yaml",
+          "*.yaml",
+          "*.yml",
+          "*.json",
           "README.md"
         ],
         "options": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,8 +16,8 @@
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
-    "baseUrl": ".",
+    "baseUrl": "."
   },
-  "include": ["src/**/*"],
+  "include": ["src"],
   "exclude": ["node_modules", "dist"]
 }

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,13 +1,27 @@
 import { defineConfig } from "tsup";
 
+/**
+ * Configuration for the tsup bundler. This configuration specifies two main entry points
+ * for building the package. The first entry point builds the utility types, generating only
+ * the .d.ts files. The second entry point handles files that need to be built in both .js and
+ * .cjs formats.
+ */
 export const tsup = defineConfig([
 	{
-		entry: ["src/*.ts"],
+		entry: ["src", "!src/validate-types.ts"],
 		format: ["esm"],
 		outDir: "dist",
 		dts: {
 			only: true,
 		},
+		minify: true,
+		clean: true,
+	},
+	{
+		entry: ["src/validate-types.ts"],
+		format: ["esm", "cjs"],
+		outDir: "dist/utils",
+		dts: true,
 		minify: true,
 		clean: true,
 	},


### PR DESCRIPTION
## Description
This pull request cleans up the codebase in severals aspects focus in remove redundance code and remove unnecesary command and improve come configuration, some of keys change includes:

- Removing `package.json` and `tsconfig.json` files from .prettierignore.
- Removing the `main` field from `package.json`.
- Removing the `build:js` command from package.json.
- Adding `.yaml`, `.yml`, and `.json` files to Prettier for formatting.
- Cleaning up `tsup.config.ts` and adding documentation to the file.



## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->