### PR TITLE
chore: set up vitest for coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ package-lock.json
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# vitest
+coverage

--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "tsup --watch",
-    "test:watch": "vitest",
     "test": "vitest --run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest --coverage",
     "build": "tsup",
     "publish": "npm run build",
     "format": "prettier --write .",
@@ -32,6 +33,7 @@
   "homepage": "https://github.com/halvaradop/ts-utility-types#readme",
   "devDependencies": {
     "@types/node": "^22.5.3",
+    "@vitest/coverage-v8": "^2.1.1",
     "prettier": "^3.3.3",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config"
+
+export default defineConfig({
+    test: {
+        coverage: {
+            provider: "v8",
+            include: ["test/**/*.test.ts"],
+            exclude: ["node_modules", "dist"],
+            reporter: ["text", "html"],
+            reportsDirectory: "test/coverage",
+        }
+    }
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,13 @@
-import { defineConfig } from "vitest/config"
+import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-    test: {
-        coverage: {
-            provider: "v8",
-            include: ["test/**/*.test.ts"],
-            exclude: ["node_modules", "dist"],
-            reporter: ["text", "html"],
-            reportsDirectory: "test/coverage",
-        }
-    }
-})
+	test: {
+		coverage: {
+			provider: "v8",
+			include: ["test/**/*.test.ts"],
+			exclude: ["node_modules", "dist"],
+			reporter: ["text", "html"],
+			reportsDirectory: "test/coverage",
+		},
+	},
+});


### PR DESCRIPTION

## Description
This pull request establishes coverage reporting using the `@vitest/coverage-v8` package, allowing for the generation of coverage reports. Key changes include

- Installed `@vitest/coverage-v8` for coverage tracking
- Configured `vitest.config.ts` to enable coverage

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->