### PR TITLE
chore: update `prettier` config and run format

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,10 +58,8 @@
   ],
   "prettier": {
     "semi": true,
-    "singleQuote": false,
     "tabWidth": 4,
     "printWidth": 130,
-    "useTabs": true,
     "overrides": [
       {
         "files": [
@@ -71,10 +69,7 @@
           "README.md"
         ],
         "options": {
-          "tabWidth": 2,
-          "useTabs": false,
-          "printWidth": 130,
-          "singleQuote": false
+          "tabWidth": 2
         }
       }
     ]

--- a/src/array-types.ts
+++ b/src/array-types.ts
@@ -10,8 +10,8 @@ import type { Equals } from "./test.js";
  * type Union = TypleToUnion<["1", "2", "3"]>;
  */
 export type TupleToUnion<Array extends readonly unknown[]> = Array extends [infer Item, ...infer Spread]
-	? Item | TupleToUnion<Spread>
-	: never;
+    ? Item | TupleToUnion<Spread>
+    : never;
 
 /**
  * Gets the length (size) of an array.
@@ -46,11 +46,11 @@ export type Last<Array extends unknown[]> = Array extends [...any, infer Last] ?
 export type Pop<Array extends unknown[]> = Array extends [...infer Spread, unknown] ? Spread : [];
 
 type FilterImplementation<Array extends unknown[], Predicate, Build extends unknown[] = []> = Array extends [
-	infer Item,
-	...infer Spread,
+    infer Item,
+    ...infer Spread,
 ]
-	? FilterImplementation<Spread, Predicate, Item extends Predicate ? [...Build, Item] : [...Build]>
-	: Build;
+    ? FilterImplementation<Spread, Predicate, Item extends Predicate ? [...Build, Item] : [...Build]>
+    : Build;
 
 /**
  * Filter the items of a tuple of elements based in the predicate provided in the
@@ -66,11 +66,11 @@ type FilterImplementation<Array extends unknown[], Predicate, Build extends unkn
 export type Filter<Array extends unknown[], Predicate> = FilterImplementation<Array, Predicate, []>;
 
 type FilterOutImplementation<Array extends readonly unknown[], Predicate, Build extends unknown[] = []> = Array extends [
-	infer Item,
-	...infer Spread,
+    infer Item,
+    ...infer Spread,
 ]
-	? FilterOutImplementation<Spread, Predicate, Item extends ToUnion<Predicate> ? Build : [...Build, Item]>
-	: Build;
+    ? FilterOutImplementation<Spread, Predicate, Item extends ToUnion<Predicate> ? Build : [...Build, Item]>
+    : Build;
 
 /**
  * Cleans the elements of a tuple based in the predicated, it returns the values that
@@ -102,13 +102,13 @@ export type FilterOut<Array extends readonly unknown[], Predicate> = FilterOutIm
 export type Reverse<Array extends unknown[]> = Array extends [infer Item, ...infer Spread] ? [...Reverse<Spread>, Item] : Array;
 
 type IndexOfImplementation<Array extends unknown[], Match, Index extends unknown[] = []> = Array extends [
-	infer Item,
-	...infer Spread,
+    infer Item,
+    ...infer Spread,
 ]
-	? Equals<Item, Match> extends true
-		? Index["length"]
-		: IndexOfImplementation<Spread, Match, [...Index, Item]>
-	: -1;
+    ? Equals<Item, Match> extends true
+        ? Index["length"]
+        : IndexOfImplementation<Spread, Match, [...Index, Item]>
+    : -1;
 
 /**
  * Returns the first index where the element `Match` appears in the tuple type `Array`.
@@ -130,20 +130,20 @@ type IndexOfImplementation<Array extends unknown[], Match, Index extends unknown
 export type IndexOf<Array extends unknown[], Match> = IndexOfImplementation<Array, Match, []>;
 
 type LastIndexOfImplementation<
-	Array extends unknown[],
-	Match,
-	Index extends unknown[] = [],
-	IndexOf extends unknown[] = [],
+    Array extends unknown[],
+    Match,
+    Index extends unknown[] = [],
+    IndexOf extends unknown[] = [],
 > = Array extends [infer Item, ...infer Spread]
-	? LastIndexOfImplementation<
-			Spread,
-			Match,
-			[...Index, Item],
-			Equals<Item, Match> extends true ? [...IndexOf, Index["length"]] : IndexOf
-		>
-	: IndexOf extends [...any, infer LastIndex]
-		? LastIndex
-		: -1;
+    ? LastIndexOfImplementation<
+          Spread,
+          Match,
+          [...Index, Item],
+          Equals<Item, Match> extends true ? [...IndexOf, Index["length"]] : IndexOf
+      >
+    : IndexOf extends [...any, infer LastIndex]
+      ? LastIndex
+      : -1;
 
 /**
  * Returns the last index where the element `Match` appears in the tuple type `Array`.
@@ -169,9 +169,9 @@ export type LastIndexOf<Array extends unknown[], Match> = LastIndexOfImplementat
  * Avoids the `Type instantiation is excessively deep and possibly infinite` error
  */
 type RepeatConstructTuple<
-	Length extends number,
-	Value extends unknown = unknown,
-	Array extends unknown[] = [],
+    Length extends number,
+    Value extends unknown = unknown,
+    Array extends unknown[] = [],
 > = Array["length"] extends Length ? Array : RepeatConstructTuple<Length, Value, [...Array, Value]>;
 
 /**
@@ -185,19 +185,19 @@ type RepeatConstructTuple<
  * type TupleSize3 = ConstructTuple<2, "">;
  */
 export type ConstructTuple<
-	Length extends number,
-	Value extends unknown = unknown,
-	Array extends unknown[] = [],
+    Length extends number,
+    Value extends unknown = unknown,
+    Array extends unknown[] = [],
 > = RepeatConstructTuple<Length, Value, Array>;
 
 type CheckRepeatedTupleImplementation<Array extends unknown[], Build extends unknown = never> = Array extends [
-	infer Item,
-	...infer Spread,
+    infer Item,
+    ...infer Spread,
 ]
-	? Item extends Build
-		? true
-		: CheckRepeatedTupleImplementation<Spread, Build | Item>
-	: false;
+    ? Item extends Build
+        ? true
+        : CheckRepeatedTupleImplementation<Spread, Build | Item>
+    : false;
 
 /**
  * Check if there are duplidated elements inside the tuple
@@ -222,31 +222,31 @@ export type CheckRepeatedTuple<Tuple extends unknown[]> = CheckRepeatedTupleImpl
  * type Test2 = AllEquals<[[1], [1], [1]], [1]>;
  */
 export type AllEquals<Array extends unknown[], Comparator> = Array extends [infer Item, ...infer Spread]
-	? Equals<Item, Comparator> extends true
-		? AllEquals<Spread, Comparator>
-		: false
-	: true;
+    ? Equals<Item, Comparator> extends true
+        ? AllEquals<Spread, Comparator>
+        : false
+    : true;
 
 type ChunkImplementation<
-	Array extends unknown[],
-	Size extends number,
-	Build extends unknown[] = [],
-	Partition extends unknown[] = [],
+    Array extends unknown[],
+    Size extends number,
+    Build extends unknown[] = [],
+    Partition extends unknown[] = [],
 > = Array extends [infer Item, ...infer Spread]
-	? [...Partition, Item]["length"] extends Size
-		? ChunkImplementation<Spread, Size, [...Build, [...Partition, Item]], []>
-		: ChunkImplementation<Spread, Size, Build, [...Partition, Item]>
-	: Partition["length"] extends 0
-		? Build
-		: [...Build, Partition];
+    ? [...Partition, Item]["length"] extends Size
+        ? ChunkImplementation<Spread, Size, [...Build, [...Partition, Item]], []>
+        : ChunkImplementation<Spread, Size, Build, [...Partition, Item]>
+    : Partition["length"] extends 0
+      ? Build
+      : [...Build, Partition];
 
 export type Chunk<Array extends unknown[], Size extends number> = ChunkImplementation<Array, Size, [], []>;
 
 type ZipImplementation<T, U, Build extends unknown[] = []> = T extends [infer ItemT, ...infer SpreadT]
-	? U extends [infer ItemU, ...infer SpreadU]
-		? ZipImplementation<SpreadT, SpreadU, [...Build, [ItemT, ItemU]]>
-		: Build
-	: Build;
+    ? U extends [infer ItemU, ...infer SpreadU]
+        ? ZipImplementation<SpreadT, SpreadU, [...Build, [ItemT, ItemU]]>
+        : Build
+    : Build;
 
 /**
  * Join the elements of two arrays in a tuple of arrays

--- a/src/object-types.ts
+++ b/src/object-types.ts
@@ -8,7 +8,7 @@ import type { ArgsFunction, ReturnTypeOf } from "./types.js";
  * It doesn't change the original object type.
  */
 export type Prettify<Obj extends object> = {
-	[Property in keyof Obj]: Obj[Property];
+    [Property in keyof Obj]: Obj[Property];
 } & {};
 
 /**
@@ -27,11 +27,11 @@ export type Prettify<Obj extends object> = {
  * type ReadonlyUser = DeepReadonly<User>;
  */
 export type DeepReadonly<Obj extends object> = {
-	readonly [Property in keyof Obj]: Obj[Property] extends Function
-		? Obj[Property]
-		: Obj[Property] extends object
-			? DeepReadonly<Obj[Property]>
-			: Obj[Property];
+    readonly [Property in keyof Obj]: Obj[Property] extends Function
+        ? Obj[Property]
+        : Obj[Property] extends object
+          ? DeepReadonly<Obj[Property]>
+          : Obj[Property];
 };
 
 /**
@@ -43,11 +43,11 @@ export type Exclude<T, Match> = T extends Match ? never : T;
  * Get the type of the resolved value of a PromiseLike object.
  */
 export type Awaited<T extends PromiseLike<unknown>> =
-	T extends PromiseLike<infer ResolveType>
-		? ResolveType extends PromiseLike<unknown>
-			? Awaited<ResolveType>
-			: ResolveType
-		: never;
+    T extends PromiseLike<infer ResolveType>
+        ? ResolveType extends PromiseLike<unknown>
+            ? Awaited<ResolveType>
+            : ResolveType
+        : never;
 
 /**
  * Get the type of the function's arguments
@@ -76,7 +76,7 @@ export type Parameters<Function extends ArgsFunction> = Function extends (...arg
  * type PickUser = Pick<User, "age">;
  */
 export type Pick<Obj extends object, Keys extends keyof Obj> = {
-	[Property in Keys]: Obj[Property];
+    [Property in Keys]: Obj[Property];
 };
 
 /**
@@ -93,10 +93,10 @@ export type Pick<Obj extends object, Keys extends keyof Obj> = {
  * type NoIncludes = Includes<["foo", "bar", "foofoo"], "foobar">;
  */
 export type Includes<Array extends unknown[], Match> = Array extends [infer Compare, ...infer Spread]
-	? Equals<Compare, Match> extends true
-		? true
-		: Includes<Spread, Match>
-	: false;
+    ? Equals<Compare, Match> extends true
+        ? true
+        : Includes<Spread, Match>
+    : false;
 
 /**
  * Creates a new type that omits properties from an object type based on another type
@@ -106,7 +106,7 @@ export type Includes<Array extends unknown[], Match> = Array extends [infer Comp
  * type NoEmailPerson = Omit<{ name: string; age: number; email: string }, "email">;
  */
 export type Omit<Obj extends object, Keys extends keyof Obj> = {
-	[Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
+    [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
 };
 
 /**
@@ -145,7 +145,7 @@ export type Properties<Obj1 extends object, Obj2 extends object> = keyof Obj1 | 
  * type MergeConfig = Merge<Config, AppStore>;
  */
 export type Merge<Obj1 extends object, Obj2 extends object> = {
-	[Property in Properties<Obj1, Obj2>]: RetrieveKeyValue<Obj2, Obj1, Property>;
+    [Property in Properties<Obj1, Obj2>]: RetrieveKeyValue<Obj2, Obj1, Property>;
 };
 
 /**
@@ -167,11 +167,11 @@ export type Merge<Obj1 extends object, Obj2 extends object> = {
  * type DiffFoo = Intersection<Foo, Bar>;
  */
 export type Intersection<Obj1 extends object, Obj2 extends object> = {
-	[Property in Properties<Obj1, Obj2> as Property extends keyof Obj1 & keyof Obj2 ? never : Property]: RetrieveKeyValue<
-		Obj1,
-		Obj2,
-		Property
-	>;
+    [Property in Properties<Obj1, Obj2> as Property extends keyof Obj1 & keyof Obj2 ? never : Property]: RetrieveKeyValue<
+        Obj1,
+        Obj2,
+        Property
+    >;
 };
 
 /**
@@ -188,7 +188,7 @@ export type Intersection<Obj1 extends object, Obj2 extends object> = {
  * type UserStr = PickByType<User, string>;
  */
 export type PickByType<Obj extends object, Type> = {
-	[Property in keyof Obj as Obj[Property] extends Type ? Property : never]: Obj[Property];
+    [Property in keyof Obj as Obj[Property] extends Type ? Property : never]: Obj[Property];
 };
 
 /**
@@ -205,9 +205,9 @@ export type PickByType<Obj extends object, Type> = {
  * type UserPartialName = PartialByKeys<User, "name">;
  */
 export type PartialByKeys<Obj extends object, Keys extends keyof Obj = keyof Obj> = Prettify<
-	{
-		[Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
-	} & { [Property in Keys]?: Obj[Property] }
+    {
+        [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
+    } & { [Property in Keys]?: Obj[Property] }
 >;
 
 /**
@@ -224,7 +224,7 @@ export type PartialByKeys<Obj extends object, Keys extends keyof Obj = keyof Obj
  * type UserExcludeStrings = OmitByType<User, string>;
  */
 export type OmitByType<Obj extends object, Type> = {
-	[Property in keyof Obj as Obj[Property] extends Type ? never : Property]: Obj[Property];
+    [Property in keyof Obj as Obj[Property] extends Type ? never : Property]: Obj[Property];
 };
 
 /**
@@ -232,16 +232,16 @@ export type OmitByType<Obj extends object, Type> = {
  * while keeping the other values unchanged.
  */
 export type FlattenProperties<Obj extends object, Keys extends keyof Obj> = Prettify<
-	{
-		[Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
-	} & Obj[Keys]
+    {
+        [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
+    } & Obj[Keys]
 >;
 
 /**
  * Removes the properties whose keys start with an underscore (_).
  */
 export type PublicOnly<Obj extends object> = {
-	[Property in keyof Obj as Property extends `_${string}` ? never : Property]: Obj[Property];
+    [Property in keyof Obj as Property extends `_${string}` ? never : Property]: Obj[Property];
 };
 
 /**
@@ -249,10 +249,10 @@ export type PublicOnly<Obj extends object> = {
  * If the key does not exist in either object, it returns `never`.
  */
 export type RetrieveKeyValue<Obj1 extends object, Obj2 extends object, Key> = Key extends keyof Obj1
-	? Obj1[Key]
-	: Key extends keyof Obj2
-		? Obj2[Key]
-		: never;
+    ? Obj1[Key]
+    : Key extends keyof Obj2
+      ? Obj2[Key]
+      : never;
 
 /**
  * Convert to required the keys speficied in the type `Keys`, and the others fields mantein
@@ -269,11 +269,11 @@ export type RetrieveKeyValue<Obj1 extends object, Obj2 extends object, Key> = Ke
  * type UserRequiredName = RequiredByKeys<User, "name">;
  */
 export type RequiredByKeys<Obj extends object, Keys extends keyof Obj = keyof Obj> = Prettify<
-	{
-		[Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
-	} & {
-		[Property in keyof Obj as Property extends Keys ? Property : never]-?: Obj[Property];
-	}
+    {
+        [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
+    } & {
+        [Property in keyof Obj as Property extends Keys ? Property : never]-?: Obj[Property];
+    }
 >;
 
 /**
@@ -293,13 +293,13 @@ export type RequiredByKeys<Obj extends object, Keys extends keyof Obj = keyof Ob
  * type MergeFooBar = UnionMerge<Foo, Bar>;
  */
 export type UnionMerge<Obj1 extends object, Obj2 extends object> = {
-	[Prop in Properties<Obj1, Obj2>]: Prop extends keyof Obj1
-		? Prop extends keyof Obj2
-			? Obj1[Prop] | Obj2[Prop]
-			: Obj1[Prop]
-		: Prop extends keyof Obj2
-			? Obj2[Prop]
-			: never;
+    [Prop in Properties<Obj1, Obj2>]: Prop extends keyof Obj1
+        ? Prop extends keyof Obj2
+            ? Obj1[Prop] | Obj2[Prop]
+            : Obj1[Prop]
+        : Prop extends keyof Obj2
+          ? Obj2[Prop]
+          : never;
 };
 
 /**
@@ -318,7 +318,7 @@ export type UnionMerge<Obj1 extends object, Obj2 extends object> = {
  * type NonReadonlyUser = Mutable<User>;
  */
 export type Mutable<Obj extends object> = {
-	-readonly [Property in keyof Obj]: Obj[Property];
+    -readonly [Property in keyof Obj]: Obj[Property];
 };
 
 /**
@@ -338,15 +338,15 @@ export type Mutable<Obj extends object> = {
  * type NonReadonlyFoo = DeepMutable<Foo>;
  */
 export type DeepMutable<Obj extends object> = {
-	-readonly [Property in keyof Obj]: Obj[Property] extends object ? DeepMutable<Obj[Property]> : Obj[Property];
+    -readonly [Property in keyof Obj]: Obj[Property] extends object ? DeepMutable<Obj[Property]> : Obj[Property];
 };
 
 type MergeAllImplementation<Array extends readonly object[], Merge extends object = {}> = Array extends [
-	infer Item,
-	...infer Spread,
+    infer Item,
+    ...infer Spread,
 ]
-	? MergeAllImplementation<Spread extends object[] ? Spread : never, UnionMerge<Merge, Item extends object ? Item : {}>>
-	: Merge;
+    ? MergeAllImplementation<Spread extends object[] ? Spread : never, UnionMerge<Merge, Item extends object ? Item : {}>>
+    : Merge;
 
 /**
  * Create a new object type based in the tuple of object types, if the properties
@@ -401,7 +401,7 @@ export type ToUnion<T> = T extends [infer Item, ...infer Spread] ? Item | ToUnio
  * type UserAppendLastname = AddPropertyToObject<User, "lastname", string>;
  */
 export type AddPropertyToObject<Obj extends object, NewProp extends string, TypeValue> = {
-	[Property in keyof Obj | NewProp]: Property extends keyof Obj ? Obj[Property] : TypeValue;
+    [Property in keyof Obj | NewProp]: Property extends keyof Obj ? Obj[Property] : TypeValue;
 };
 
 /**
@@ -418,7 +418,7 @@ export type AddPropertyToObject<Obj extends object, NewProp extends string, Type
  * type FooEntries = ObjectEntries<Foo>;
  */
 export type ObjectEntries<Obj extends object, RequiredObj extends object = Required<Obj>> = {
-	[Property in keyof RequiredObj]: [Property, RequiredObj[Property] extends undefined ? undefined : RequiredObj[Property]];
+    [Property in keyof RequiredObj]: [Property, RequiredObj[Property] extends undefined ? undefined : RequiredObj[Property]];
 }[keyof RequiredObj];
 
 /**
@@ -436,11 +436,11 @@ export type ObjectEntries<Obj extends object, RequiredObj extends object = Requi
  * type ReplaceStrings = ReplaceKeys<Foo, "foo" | "foobar", { foo: number, foobar: number }>;
  */
 export type ReplaceKeys<Obj extends object, Keys extends string, Replace extends object, Default = unknown> = {
-	[Property in keyof Obj]: Property extends Keys
-		? Property extends keyof Replace
-			? Replace[Property]
-			: Default
-		: Obj[Property];
+    [Property in keyof Obj]: Property extends Keys
+        ? Property extends keyof Replace
+            ? Replace[Property]
+            : Default
+        : Obj[Property];
 };
 
 /**
@@ -455,13 +455,13 @@ export type ReplaceKeys<Obj extends object, Keys extends string, Replace extends
  * type ReplaceTypesII = MapTypes<{ foo: string, bar: string }, { from: string, bar: number }>;
  */
 export type MapTypes<Obj extends object, Mapper extends { from: unknown; to: unknown }> = {
-	[Property in keyof Obj]: Obj[Property] extends Mapper["from"]
-		? Mapper extends { from: infer From; to: infer To }
-			? Obj[Property] extends From
-				? To
-				: never
-			: Obj[Property]
-		: Obj[Property];
+    [Property in keyof Obj]: Obj[Property] extends Mapper["from"]
+        ? Mapper extends { from: infer From; to: infer To }
+            ? Obj[Property] extends From
+                ? To
+                : never
+            : Obj[Property]
+        : Obj[Property];
 };
 
 /**
@@ -483,17 +483,17 @@ export type MapTypes<Obj extends object, Mapper extends { from: unknown; to: unk
  * type OmitNameUser = DeepOmit<User, "name">;
  */
 export type DeepOmit<Obj extends object, Pattern extends string> = {
-	[Property in keyof Obj as Pattern extends `${string}.${string}`
-		? Property
-		: Property extends Pattern
-			? never
-			: Property]: Pattern extends `${infer StartsWith}.${infer Spread}`
-		? Property extends StartsWith
-			? Obj[Property] extends object
-				? DeepOmit<Obj[Property], Spread>
-				: Obj[Property]
-			: Obj[Property]
-		: Obj[Property];
+    [Property in keyof Obj as Pattern extends `${string}.${string}`
+        ? Property
+        : Property extends Pattern
+          ? never
+          : Property]: Pattern extends `${infer StartsWith}.${infer Spread}`
+        ? Property extends StartsWith
+            ? Obj[Property] extends object
+                ? DeepOmit<Obj[Property], Spread>
+                : Obj[Property]
+            : Obj[Property]
+        : Obj[Property];
 };
 
 /**
@@ -511,9 +511,9 @@ export type DeepOmit<Obj extends object, Pattern extends string> = {
  * type UserPrimitive = ToPrimitive<User>;
  */
 export type ToPrimitive<Obj extends object> = {
-	[Property in keyof Obj]: Obj[Property] extends object
-		? Obj[Property] extends Function
-			? Function
-			: ToPrimitive<Obj[Property]>
-		: ReturnTypeOf<Obj[Property]>;
+    [Property in keyof Obj]: Obj[Property] extends object
+        ? Obj[Property] extends Function
+            ? Function
+            : ToPrimitive<Obj[Property]>
+        : ReturnTypeOf<Obj[Property]>;
 };

--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -24,48 +24,48 @@ export type TrimRight<Str extends string> = Str extends `${infer Char}${WhiteSpa
  * type Trimmed = Trim<"  hello world  ">;
  */
 export type Trim<Str extends string> = Str extends `${WhiteSpaces}${infer Characters}`
-	? Trim<Characters>
-	: Str extends `${infer Char}${WhiteSpaces}`
-		? Trim<Char>
-		: Str;
+    ? Trim<Characters>
+    : Str extends `${infer Char}${WhiteSpaces}`
+      ? Trim<Char>
+      : Str;
 
 /**
  *  Converts a string to uppercase
  */
 export type Uppercase<Str extends string> = Str extends `${infer Char}${infer Characters}`
-	? Char extends keyof LetterToUppercase
-		? `${LetterToUppercase[Char]}${Uppercase<Characters>}`
-		: `${Char}${Uppercase<Characters>}`
-	: Str;
+    ? Char extends keyof LetterToUppercase
+        ? `${LetterToUppercase[Char]}${Uppercase<Characters>}`
+        : `${Char}${Uppercase<Characters>}`
+    : Str;
 
 /**
  * Converts a string to lowercase
  */
 export type Lowercase<Str extends string> = Str extends `${infer Char}${infer Characters}`
-	? Char extends keyof LetterToLowercase
-		? `${LetterToLowercase[Char]}${Lowercase<Characters>}`
-		: `${Char}${Lowercase<Characters>}`
-	: Str;
+    ? Char extends keyof LetterToLowercase
+        ? `${LetterToLowercase[Char]}${Lowercase<Characters>}`
+        : `${Char}${Lowercase<Characters>}`
+    : Str;
 
 /**
  * Capitalizes the first letter of a word and converts the rest to lowercase
  */
 export type Capitalize<Str extends string, FirstWord extends boolean = true> = Str extends `${infer Char}${infer Characters}`
-	? FirstWord extends boolean
-		? FirstWord extends true
-			? `${Uppercase<Char>}${Capitalize<Characters, false>}`
-			: Char extends " "
-				? ` ${Capitalize<Characters, true>}`
-				: `${Lowercase<Char>}${Capitalize<Characters, false>}`
-		: Str
-	: Str;
+    ? FirstWord extends boolean
+        ? FirstWord extends true
+            ? `${Uppercase<Char>}${Capitalize<Characters, false>}`
+            : Char extends " "
+              ? ` ${Capitalize<Characters, true>}`
+              : `${Lowercase<Char>}${Capitalize<Characters, false>}`
+        : Str
+    : Str;
 
 type JoinImplementation<Array extends unknown[], Separator extends number | string, Str extends string = ""> = Array extends [
-	infer Char,
-	...infer Chars,
+    infer Char,
+    ...infer Chars,
 ]
-	? JoinImplementation<Chars, Separator, `${Str}${Str extends "" ? "" : Separator}${Char & string}`>
-	: Str;
+    ? JoinImplementation<Chars, Separator, `${Str}${Str extends "" ? "" : Separator}${Char & string}`>
+    : Str;
 
 /**
  * Create a string type based on the values of a tuple type `T`, joining the values
@@ -96,12 +96,12 @@ export type Join<Array extends unknown[], Separator extends number | string> = J
 export type StartsWith<Str extends string, Match extends string> = Str extends `${Match}${string}` ? true : false;
 
 type DropCharImplementation<
-	Str extends string,
-	Match extends string,
-	Build extends string = "",
+    Str extends string,
+    Match extends string,
+    Build extends string = "",
 > = Str extends `${infer Char}${infer Chars}`
-	? DropCharImplementation<Chars, Match, Char extends Match ? Build : `${Build}${Char}`>
-	: Build;
+    ? DropCharImplementation<Chars, Match, Char extends Match ? Build : `${Build}${Char}`>
+    : Build;
 
 /**
  * Returns a new string type by removing all occurrences of the character `Match` from the string `Str`
@@ -128,8 +128,8 @@ export type DropChar<Str extends string, Match extends string> = DropCharImpleme
 export type EndsWith<Str extends string, Match extends string> = Str extends `${string}${Match}` ? true : false;
 
 type LengthOfStringImplementation<Str extends string, Length extends unknown[] = []> = Str extends `${infer Char}${infer Chars}`
-	? LengthOfStringImplementation<Chars, [...Length, Char]>
-	: Length["length"];
+    ? LengthOfStringImplementation<Chars, [...Length, Char]>
+    : Length["length"];
 
 /**
  * Returns the length of a string type
@@ -144,14 +144,14 @@ type LengthOfStringImplementation<Str extends string, Length extends unknown[] =
 export type LengthOfString<Str extends string> = LengthOfStringImplementation<Str>;
 
 type IndexOfStringImplementation<
-	Str extends string,
-	Match extends string,
-	Index extends unknown[] = [],
+    Str extends string,
+    Match extends string,
+    Index extends unknown[] = [],
 > = Str extends `${infer Char}${infer Chars}`
-	? Equals<Char, Match> extends true
-		? Index["length"]
-		: IndexOfStringImplementation<Chars, Match, [...Index, 1]>
-	: -1;
+    ? Equals<Char, Match> extends true
+        ? Index["length"]
+        : IndexOfStringImplementation<Chars, Match, [...Index, 1]>
+    : -1;
 
 /**
  * Returns the first index of the character that matches `Match`.
@@ -167,16 +167,16 @@ type IndexOfStringImplementation<
 export type IndexOfString<Str extends string, Match extends string> = IndexOfStringImplementation<Str, Match>;
 
 type FirstUniqueCharIndexImplementation<
-	Str extends string,
-	Index extends unknown[] = [],
-	Build extends string = "",
+    Str extends string,
+    Index extends unknown[] = [],
+    Build extends string = "",
 > = Str extends `${infer Char}${infer Chars}`
-	? IndexOfString<Chars, Char> extends -1
-		? Char extends Build
-			? FirstUniqueCharIndexImplementation<Chars, [...Index, 1], Char | Build>
-			: Index["length"]
-		: FirstUniqueCharIndexImplementation<Chars, [...Index, 1], Char | Build>
-	: -1;
+    ? IndexOfString<Chars, Char> extends -1
+        ? Char extends Build
+            ? FirstUniqueCharIndexImplementation<Chars, [...Index, 1], Char | Build>
+            : Index["length"]
+        : FirstUniqueCharIndexImplementation<Chars, [...Index, 1], Char | Build>
+    : -1;
 
 /**
  * Returns the first index of a character that is unique within the given string.
@@ -202,19 +202,19 @@ export type FirstUniqueCharIndex<Str extends string> = FirstUniqueCharIndexImple
  * type Replace2 = Replace<"foobarbar", "bar", "foo">
  */
 export type Replace<S extends string, From extends string, To extends string> = From extends ""
-	? S
-	: S extends `${infer Head}${From}${infer Tail}`
-		? `${Head}${To}${Tail}`
-		: S;
+    ? S
+    : S extends `${infer Head}${From}${infer Tail}`
+      ? `${Head}${To}${Tail}`
+      : S;
 
 type CheckRepeatedCharsImplementation<
-	Str extends string,
-	Characters extends string = "",
+    Str extends string,
+    Characters extends string = "",
 > = Str extends `${infer Char}${infer Chars}`
-	? Char extends Characters
-		? true
-		: CheckRepeatedCharsImplementation<Chars, Characters | Char>
-	: false;
+    ? Char extends Characters
+        ? true
+        : CheckRepeatedCharsImplementation<Chars, Characters | Char>
+    : false;
 
 /**
  * Check if there are repeated characters in a string type
@@ -229,15 +229,15 @@ type CheckRepeatedCharsImplementation<
 export type CheckRepeatedChars<Str extends string> = CheckRepeatedCharsImplementation<Str>;
 
 type ParseUrlParamsImplementation<
-	URLParams extends string,
-	Params extends string = never,
+    URLParams extends string,
+    Params extends string = never,
 > = URLParams extends `${infer Segment}/${infer Route}`
-	? Segment extends `:${infer WithoutDots}`
-		? ParseUrlParamsImplementation<Route, Params | WithoutDots>
-		: ParseUrlParamsImplementation<Route, Params>
-	: URLParams extends `:${infer WithoutDots}`
-		? Params | WithoutDots
-		: Params;
+    ? Segment extends `:${infer WithoutDots}`
+        ? ParseUrlParamsImplementation<Route, Params | WithoutDots>
+        : ParseUrlParamsImplementation<Route, Params>
+    : URLParams extends `:${infer WithoutDots}`
+      ? Params | WithoutDots
+      : Params;
 
 /**
  * eturns a union type of the dynamic route parameters in a URL pattern
@@ -252,17 +252,17 @@ type ParseUrlParamsImplementation<
 export type ParseUrlParams<URLParams extends string> = ParseUrlParamsImplementation<URLParams>;
 
 type FindAllImplementation<
-	Str extends string,
-	Match extends string,
-	Index extends unknown[] = [],
-	Indexes extends unknown[] = [],
+    Str extends string,
+    Match extends string,
+    Index extends unknown[] = [],
+    Indexes extends unknown[] = [],
 > = Match extends ""
-	? Indexes
-	: Str extends `${any}${infer Characters}`
-		? Str extends `${Match}${string}`
-			? FindAllImplementation<Characters, Match, [...Index, 1], [...Indexes, Index["length"]]>
-			: FindAllImplementation<Characters, Match, [...Index, 1], Indexes>
-		: Indexes;
+    ? Indexes
+    : Str extends `${any}${infer Characters}`
+      ? Str extends `${Match}${string}`
+          ? FindAllImplementation<Characters, Match, [...Index, 1], [...Indexes, Index["length"]]>
+          : FindAllImplementation<Characters, Match, [...Index, 1], Indexes>
+      : Indexes;
 
 /**
  * Returns indexes the substring that matches `Match` in the string `Str`

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,64 +42,64 @@ export type WhiteSpaces = " " | "\n" | "\t" | "\r" | "\f" | "\u2028" | "\u2029";
  * Maps lowercase letters to their uppercase equivalents
  */
 export interface LetterToUppercase {
-	a: "A";
-	b: "B";
-	c: "C";
-	d: "D";
-	e: "E";
-	f: "F";
-	g: "G";
-	h: "H";
-	i: "I";
-	j: "J";
-	k: "K";
-	l: "L";
-	m: "M";
-	n: "N";
-	o: "O";
-	p: "P";
-	q: "Q";
-	r: "R";
-	s: "S";
-	t: "T";
-	u: "U";
-	v: "V";
-	w: "W";
-	x: "X";
-	y: "Y";
-	z: "Z";
+    a: "A";
+    b: "B";
+    c: "C";
+    d: "D";
+    e: "E";
+    f: "F";
+    g: "G";
+    h: "H";
+    i: "I";
+    j: "J";
+    k: "K";
+    l: "L";
+    m: "M";
+    n: "N";
+    o: "O";
+    p: "P";
+    q: "Q";
+    r: "R";
+    s: "S";
+    t: "T";
+    u: "U";
+    v: "V";
+    w: "W";
+    x: "X";
+    y: "Y";
+    z: "Z";
 }
 
 /**
  * Maps uppercase letters to their lowercase equivalents
  */
 export interface LetterToLowercase {
-	A: "a";
-	B: "b";
-	C: "c";
-	D: "d";
-	E: "e";
-	F: "f";
-	G: "g";
-	H: "h";
-	I: "i";
-	J: "j";
-	K: "k";
-	L: "l";
-	M: "m";
-	N: "n";
-	O: "o";
-	P: "p";
-	Q: "q";
-	R: "r";
-	S: "s";
-	T: "t";
-	U: "u";
-	V: "v";
-	W: "w";
-	X: "x";
-	Y: "y";
-	Z: "z";
+    A: "a";
+    B: "b";
+    C: "c";
+    D: "d";
+    E: "e";
+    F: "f";
+    G: "g";
+    H: "h";
+    I: "i";
+    J: "j";
+    K: "k";
+    L: "l";
+    M: "m";
+    N: "n";
+    O: "o";
+    P: "p";
+    Q: "q";
+    R: "r";
+    S: "s";
+    T: "t";
+    U: "u";
+    V: "v";
+    W: "w";
+    X: "x";
+    Y: "y";
+    Z: "z";
 }
 
 /**
@@ -128,13 +128,13 @@ export type Even = 0 | 2 | 4 | 6 | 8;
  * type TypeOfValue = TypeOf<"hello">
  */
 export type ReturnTypeOf<T> = T extends string
-	? string
-	: T extends number
-		? number
-		: T extends object
-			? object
-			: T extends boolean
-				? boolean
-				: T extends Function
-					? Function
-					: never;
+    ? string
+    : T extends number
+      ? number
+      : T extends object
+        ? object
+        : T extends boolean
+          ? boolean
+          : T extends Function
+            ? Function
+            : never;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,21 +14,21 @@ import type { DropChar } from "./string-mappers.js";
  * type Test2 = PercentageParser<"+89%">;
  */
 export type PercentageParser<
-	Percentage extends string,
-	Sign extends string = "",
-	Num extends string = "",
-	Unit extends string = "",
+    Percentage extends string,
+    Sign extends string = "",
+    Num extends string = "",
+    Unit extends string = "",
 > = Percentage extends `${infer Char}${infer Chars}`
-	? Char extends "+" | "-"
-		? PercentageParser<Chars, Char, Num, Unit>
-		: Char extends "%"
-			? PercentageParser<Chars, Sign, Num, "%">
-			: Char extends `${number}`
-				? PercentageParser<Chars, Sign, `${Num}${Char}`, Unit>
-				: Char extends "." | ","
-					? PercentageParser<Char, Sign, `${Num}${Char}`, Unit>
-					: never
-	: [Sign, Num, Unit];
+    ? Char extends "+" | "-"
+        ? PercentageParser<Chars, Char, Num, Unit>
+        : Char extends "%"
+          ? PercentageParser<Chars, Sign, Num, "%">
+          : Char extends `${number}`
+            ? PercentageParser<Chars, Sign, `${Num}${Char}`, Unit>
+            : Char extends "." | ","
+              ? PercentageParser<Char, Sign, `${Num}${Char}`, Unit>
+              : never
+    : [Sign, Num, Unit];
 
 /**
  * Returns the absolute version of a number, string or bigint as a string
@@ -46,12 +46,12 @@ export type Absolute<Expression extends number | string | bigint> = DropChar<`${
  * type TruncatedNegative = Trunc<-2.99>;
  */
 export type Trunc<Math extends string | number | bigint> = `${Math}` extends `.${number}`
-	? "0"
-	: `${Math}` extends `${infer Chars}.${number}`
-		? Chars extends `-0${string}`
-			? "0"
-			: Chars
-		: `${Math}`;
+    ? "0"
+    : `${Math}` extends `${infer Chars}.${number}`
+      ? Chars extends `-0${string}`
+          ? "0"
+          : Chars
+      : `${Math}`;
 
 /**
  * Creates a series of numbers between the range of `Low` and `High`. This utility type
@@ -60,18 +60,18 @@ export type Trunc<Math extends string | number | bigint> = `${Math}` extends `.$
  * @link `NumberRange`
  */
 type NumberRangeImplementation<
-	Low extends number,
-	High extends number,
-	Range extends unknown = never,
-	Index extends unknown[] = [],
-	LowRange extends boolean = false,
+    Low extends number,
+    High extends number,
+    Range extends unknown = never,
+    Index extends unknown[] = [],
+    LowRange extends boolean = false,
 > = Index["length"] extends Low
-	? NumberRangeImplementation<Low, High, Range | Index["length"], [...Index, 1], true>
-	: Index["length"] extends High
-		? Range | Index["length"]
-		: LowRange extends true
-			? NumberRangeImplementation<Low, High, Range | Index["length"], [...Index, 1], LowRange>
-			: NumberRangeImplementation<Low, High, Range, [...Index, 1], LowRange>;
+    ? NumberRangeImplementation<Low, High, Range | Index["length"], [...Index, 1], true>
+    : Index["length"] extends High
+      ? Range | Index["length"]
+      : LowRange extends true
+        ? NumberRangeImplementation<Low, High, Range | Index["length"], [...Index, 1], LowRange>
+        : NumberRangeImplementation<Low, High, Range, [...Index, 1], LowRange>;
 
 /**
  * Creates a range of numbers that starts from `Low` and ends in `High`. The range is inclusive
@@ -86,9 +86,9 @@ type NumberRangeImplementation<
  * type Range2 = NumberRange<-1, 5>;
  */
 export type NumberRange<Low extends number, High extends number> = `${Low}` extends `-${number}`
-	? never
-	: `${High}` extends `-${number}`
-		? never
-		: Low extends High
-			? Low
-			: NumberRangeImplementation<Low, High>;
+    ? never
+    : `${High}` extends `-${number}`
+      ? never
+      : Low extends High
+        ? Low
+        : NumberRangeImplementation<Low, High>;

--- a/src/validate-types.ts
+++ b/src/validate-types.ts
@@ -12,7 +12,7 @@ const primitives = ["number", "string", "boolean", "bigint", "symbol"];
  * @returns {boolean} `true` if the value is a primitive type, `false` otherwise
  */
 export const isPrimitive = (value: unknown): value is Primitive => {
-	return primitives.some((primitive) => typeof value === primitive);
+    return primitives.some((primitive) => typeof value === primitive);
 };
 
 /**

--- a/test/array-types.test.ts
+++ b/test/array-types.test.ts
@@ -2,147 +2,147 @@ import { describe, test, expectTypeOf } from "vitest";
 import type * as utilities from "../src/array-types";
 
 describe("TupleToUnion", () => {
-	test("Create union type", () => {
-		expectTypeOf<utilities.TupleToUnion<["foo", "bar"]>>().toEqualTypeOf<"foo" | "bar">();
-		expectTypeOf<utilities.TupleToUnion<[1, 2]>>().toEqualTypeOf<1 | 2>();
-		expectTypeOf<utilities.TupleToUnion<["foo", 1, "bar", 2]>>().toEqualTypeOf<"foo" | "bar" | 1 | 2>();
-	});
+    test("Create union type", () => {
+        expectTypeOf<utilities.TupleToUnion<["foo", "bar"]>>().toEqualTypeOf<"foo" | "bar">();
+        expectTypeOf<utilities.TupleToUnion<[1, 2]>>().toEqualTypeOf<1 | 2>();
+        expectTypeOf<utilities.TupleToUnion<["foo", 1, "bar", 2]>>().toEqualTypeOf<"foo" | "bar" | 1 | 2>();
+    });
 });
 
 describe("Tuple methods", () => {
-	describe("Last", () => {
-		test("Retrieve the last element of a tuple", () => {
-			expectTypeOf<utilities.Last<[]>>().toEqualTypeOf<never>();
-			expectTypeOf<utilities.Last<[1, 2, 3]>>().toEqualTypeOf<3>();
-			expectTypeOf<utilities.Last<["foo", "bar", "foobar"]>>().toEqualTypeOf<"foobar">();
-		});
-	});
+    describe("Last", () => {
+        test("Retrieve the last element of a tuple", () => {
+            expectTypeOf<utilities.Last<[]>>().toEqualTypeOf<never>();
+            expectTypeOf<utilities.Last<[1, 2, 3]>>().toEqualTypeOf<3>();
+            expectTypeOf<utilities.Last<["foo", "bar", "foobar"]>>().toEqualTypeOf<"foobar">();
+        });
+    });
 
-	describe("Pop", () => {
-		test("Remove the last element of a tuple", () => {
-			expectTypeOf<utilities.Pop<[]>>().toEqualTypeOf<[]>();
-			expectTypeOf<utilities.Pop<[1, 2, 3]>>().toEqualTypeOf<[1, 2]>();
-			expectTypeOf<utilities.Pop<["foo", "bar", "foobar"]>>().toEqualTypeOf<["foo", "bar"]>();
-		});
-	});
+    describe("Pop", () => {
+        test("Remove the last element of a tuple", () => {
+            expectTypeOf<utilities.Pop<[]>>().toEqualTypeOf<[]>();
+            expectTypeOf<utilities.Pop<[1, 2, 3]>>().toEqualTypeOf<[1, 2]>();
+            expectTypeOf<utilities.Pop<["foo", "bar", "foobar"]>>().toEqualTypeOf<["foo", "bar"]>();
+        });
+    });
 
-	describe("Size", () => {
-		test("Returns the size of the tuple", () => {
-			expectTypeOf<utilities.Size<[]>>().toEqualTypeOf<0>();
-			expectTypeOf<utilities.Size<[1, 2, 3]>>().toEqualTypeOf<3>();
-			expectTypeOf<utilities.Size<["foo", "bar", "foobar", 1, 2, never, () => void, { foo: string }]>>().toEqualTypeOf<8>();
-		});
-	});
+    describe("Size", () => {
+        test("Returns the size of the tuple", () => {
+            expectTypeOf<utilities.Size<[]>>().toEqualTypeOf<0>();
+            expectTypeOf<utilities.Size<[1, 2, 3]>>().toEqualTypeOf<3>();
+            expectTypeOf<utilities.Size<["foo", "bar", "foobar", 1, 2, never, () => void, { foo: string }]>>().toEqualTypeOf<8>();
+        });
+    });
 
-	describe("Filter", () => {
-		test("Filter the elements based in the predicate", () => {
-			expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0>>().toEqualTypeOf<[0]>();
-			expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0 | 4>>().toEqualTypeOf<[0, 4]>();
-			expectTypeOf<utilities.Filter<[0, 0, 1, 1, 1], 1>>().toEqualTypeOf<[1, 1, 1]>();
-			expectTypeOf<utilities.Filter<["foo", "bar", "foobar"], "bar">>().toEqualTypeOf<["bar"]>();
-		});
-	});
+    describe("Filter", () => {
+        test("Filter the elements based in the predicate", () => {
+            expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0>>().toEqualTypeOf<[0]>();
+            expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0 | 4>>().toEqualTypeOf<[0, 4]>();
+            expectTypeOf<utilities.Filter<[0, 0, 1, 1, 1], 1>>().toEqualTypeOf<[1, 1, 1]>();
+            expectTypeOf<utilities.Filter<["foo", "bar", "foobar"], "bar">>().toEqualTypeOf<["bar"]>();
+        });
+    });
 
-	describe("FilterOut", () => {
-		test("Removes the elements present in the predicate", () => {
-			expectTypeOf<utilities.FilterOut<[1, 2, 3, 4, 5], [4, 5]>>().toEqualTypeOf<[1, 2, 3]>();
-			expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar"], "foo">>().toEqualTypeOf<["bar", "foobar"]>();
-			expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar", 1, 2], "foo" | 2>>().toEqualTypeOf<["bar", "foobar", 1]>();
-			expectTypeOf<
-				utilities.FilterOut<[{ foo: string }, { bar: number }, { foobar: boolean }], { bar: number }>
-			>().toEqualTypeOf<[{ foo: string }, { foobar: boolean }]>();
-			expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar", 1, 2, { foo: string }], { foo: string }>>().toEqualTypeOf<
-				["foo", "bar", "foobar", 1, 2]
-			>();
-		});
-	});
+    describe("FilterOut", () => {
+        test("Removes the elements present in the predicate", () => {
+            expectTypeOf<utilities.FilterOut<[1, 2, 3, 4, 5], [4, 5]>>().toEqualTypeOf<[1, 2, 3]>();
+            expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar"], "foo">>().toEqualTypeOf<["bar", "foobar"]>();
+            expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar", 1, 2], "foo" | 2>>().toEqualTypeOf<["bar", "foobar", 1]>();
+            expectTypeOf<
+                utilities.FilterOut<[{ foo: string }, { bar: number }, { foobar: boolean }], { bar: number }>
+            >().toEqualTypeOf<[{ foo: string }, { foobar: boolean }]>();
+            expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar", 1, 2, { foo: string }], { foo: string }>>().toEqualTypeOf<
+                ["foo", "bar", "foobar", 1, 2]
+            >();
+        });
+    });
 
-	describe("Reverse", () => {
-		test("Reverse the elements of a tuple type", () => {
-			expectTypeOf<utilities.Reverse<[1, 2, 3, 4]>>().toEqualTypeOf<[4, 3, 2, 1]>();
-			expectTypeOf<utilities.Reverse<["a", "b", "c"]>>().toEqualTypeOf<["c", "b", "a"]>();
-			expectTypeOf<utilities.Reverse<[1, "foo", 2, "bar", { foo: number }, () => void]>>().toEqualTypeOf<
-				[() => void, { foo: number }, "bar", 2, "foo", 1]
-			>();
-		});
-	});
+    describe("Reverse", () => {
+        test("Reverse the elements of a tuple type", () => {
+            expectTypeOf<utilities.Reverse<[1, 2, 3, 4]>>().toEqualTypeOf<[4, 3, 2, 1]>();
+            expectTypeOf<utilities.Reverse<["a", "b", "c"]>>().toEqualTypeOf<["c", "b", "a"]>();
+            expectTypeOf<utilities.Reverse<[1, "foo", 2, "bar", { foo: number }, () => void]>>().toEqualTypeOf<
+                [() => void, { foo: number }, "bar", 2, "foo", 1]
+            >();
+        });
+    });
 
-	describe("IndexOf", () => {
-		test("Get first index of an element", () => {
-			expectTypeOf<utilities.IndexOf<[0, 0, 0], 2>>().toEqualTypeOf<-1>();
-			expectTypeOf<utilities.IndexOf<[string, 1, number, "a"], number>>().toEqualTypeOf<2>();
-			expectTypeOf<utilities.IndexOf<[string, 1, number, "a", any], any>>().toEqualTypeOf<4>();
-			expectTypeOf<utilities.IndexOf<[string, "a"], "a">>().toEqualTypeOf<1>();
-		});
+    describe("IndexOf", () => {
+        test("Get first index of an element", () => {
+            expectTypeOf<utilities.IndexOf<[0, 0, 0], 2>>().toEqualTypeOf<-1>();
+            expectTypeOf<utilities.IndexOf<[string, 1, number, "a"], number>>().toEqualTypeOf<2>();
+            expectTypeOf<utilities.IndexOf<[string, 1, number, "a", any], any>>().toEqualTypeOf<4>();
+            expectTypeOf<utilities.IndexOf<[string, "a"], "a">>().toEqualTypeOf<1>();
+        });
 
-		test("Get last index of an element", () => {
-			expectTypeOf<utilities.LastIndexOf<[1, 2, 3, 2, 1], 2>>().toEqualTypeOf<3>();
-			expectTypeOf<utilities.LastIndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3>>().toEqualTypeOf<7>();
-			expectTypeOf<utilities.LastIndexOf<[string, 2, number, "a", number, 1], number>>().toEqualTypeOf<4>();
-			expectTypeOf<utilities.LastIndexOf<[string, any, 1, number, "a", any, 1], any>>().toEqualTypeOf<5>();
-		});
-	});
+        test("Get last index of an element", () => {
+            expectTypeOf<utilities.LastIndexOf<[1, 2, 3, 2, 1], 2>>().toEqualTypeOf<3>();
+            expectTypeOf<utilities.LastIndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3>>().toEqualTypeOf<7>();
+            expectTypeOf<utilities.LastIndexOf<[string, 2, number, "a", number, 1], number>>().toEqualTypeOf<4>();
+            expectTypeOf<utilities.LastIndexOf<[string, any, 1, number, "a", any, 1], any>>().toEqualTypeOf<5>();
+        });
+    });
 });
 
 describe("ConstructTuple", () => {
-	test("Create a tuple with a defined size", () => {
-		expectTypeOf<utilities.ConstructTuple<2>>().toEqualTypeOf<[unknown, unknown]>();
-		expectTypeOf<utilities.ConstructTuple<2, string>>().toEqualTypeOf<[string, string]>();
-		expectTypeOf<utilities.ConstructTuple<5, any>>().toEqualTypeOf<[any, any, any, any, any]>();
-	});
+    test("Create a tuple with a defined size", () => {
+        expectTypeOf<utilities.ConstructTuple<2>>().toEqualTypeOf<[unknown, unknown]>();
+        expectTypeOf<utilities.ConstructTuple<2, string>>().toEqualTypeOf<[string, string]>();
+        expectTypeOf<utilities.ConstructTuple<5, any>>().toEqualTypeOf<[any, any, any, any, any]>();
+    });
 });
 
 describe("CheckRepeatedTuple", () => {
-	test("Check if there are duplicated elements", () => {
-		expectTypeOf<utilities.CheckRepeatedTuple<[]>>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.CheckRepeatedTuple<[1, 2, 1]>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.CheckRepeatedTuple<["foo", "bar", 1, 5]>>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.CheckRepeatedTuple<[() => void, () => void]>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.CheckRepeatedTuple<[{ foo: string }, { foo: string }]>>().toEqualTypeOf<true>();
-	});
+    test("Check if there are duplicated elements", () => {
+        expectTypeOf<utilities.CheckRepeatedTuple<[]>>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.CheckRepeatedTuple<[1, 2, 1]>>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.CheckRepeatedTuple<["foo", "bar", 1, 5]>>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.CheckRepeatedTuple<[() => void, () => void]>>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.CheckRepeatedTuple<[{ foo: string }, { foo: string }]>>().toEqualTypeOf<true>();
+    });
 });
 
 describe("AllEquals", () => {
-	test("Check if all elements are equal", () => {
-		expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 1>>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 0>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.AllEquals<[0, 0, 1, 0], 1>>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.AllEquals<[number, number, number, number], number>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.AllEquals<[[1], [1], [1]], [1]>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.AllEquals<[{}, {}, {}], {}>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.AllEquals<[1, 1, 2], 1 | 2>>().toEqualTypeOf<false>();
-	});
+    test("Check if all elements are equal", () => {
+        expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 1>>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 0>>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.AllEquals<[0, 0, 1, 0], 1>>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.AllEquals<[number, number, number, number], number>>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.AllEquals<[[1], [1], [1]], [1]>>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.AllEquals<[{}, {}, {}], {}>>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.AllEquals<[1, 1, 2], 1 | 2>>().toEqualTypeOf<false>();
+    });
 });
 
 describe("Chunk", () => {
-	test("Split an array into chunks", () => {
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 1>>().toEqualTypeOf<[[1], [2], [3], [4], [5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 2>>().toEqualTypeOf<[[1, 2], [3, 4], [5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 3>>().toEqualTypeOf<[[1, 2, 3], [4, 5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 4>>().toEqualTypeOf<[[1, 2, 3, 4], [5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 5>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 6>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
-		expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], -2>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
-	});
+    test("Split an array into chunks", () => {
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 1>>().toEqualTypeOf<[[1], [2], [3], [4], [5]]>();
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 2>>().toEqualTypeOf<[[1, 2], [3, 4], [5]]>();
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 3>>().toEqualTypeOf<[[1, 2, 3], [4, 5]]>();
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 4>>().toEqualTypeOf<[[1, 2, 3, 4], [5]]>();
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 5>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 6>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], -2>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
+    });
 });
 
 describe("Zip", () => {
-	test("Zip two arrays into a tuple", () => {
-		expectTypeOf<utilities.Zip<[], []>>().toEqualTypeOf<[]>();
-		expectTypeOf<utilities.Zip<[1, 2, 3], ["foo"]>>().toEqualTypeOf<[[1, "foo"]]>();
-		expectTypeOf<utilities.Zip<[1, "bar", 3], ["foo", 2]>>().toEqualTypeOf<[[1, "foo"], ["bar", 2]]>();
-		expectTypeOf<utilities.Zip<[{ foo: string }, { bar: string }], ["foo", "bar"]>>().toEqualTypeOf<
-			[[{ foo: string }, "foo"], [{ bar: string }, "bar"]]
-		>();
-	});
+    test("Zip two arrays into a tuple", () => {
+        expectTypeOf<utilities.Zip<[], []>>().toEqualTypeOf<[]>();
+        expectTypeOf<utilities.Zip<[1, 2, 3], ["foo"]>>().toEqualTypeOf<[[1, "foo"]]>();
+        expectTypeOf<utilities.Zip<[1, "bar", 3], ["foo", 2]>>().toEqualTypeOf<[[1, "foo"], ["bar", 2]]>();
+        expectTypeOf<utilities.Zip<[{ foo: string }, { bar: string }], ["foo", "bar"]>>().toEqualTypeOf<
+            [[{ foo: string }, "foo"], [{ bar: string }, "bar"]]
+        >();
+    });
 });
 
 describe("FlattenArrayType", () => {
-	test("Flatten an array type", () => {
-		expectTypeOf<utilities.FlattenArrayType<number[]>>().toEqualTypeOf<number>();
-		expectTypeOf<utilities.FlattenArrayType<number[][]>>().toEqualTypeOf<number>();
-		expectTypeOf<utilities.FlattenArrayType<number[][][]>>().toEqualTypeOf<number>();
-		expectTypeOf<utilities.FlattenArrayType<string[][][][]>>().toEqualTypeOf<string>();
-		expectTypeOf<utilities.FlattenArrayType<unknown[][][][]>>().toEqualTypeOf<unknown>();
-	});
+    test("Flatten an array type", () => {
+        expectTypeOf<utilities.FlattenArrayType<number[]>>().toEqualTypeOf<number>();
+        expectTypeOf<utilities.FlattenArrayType<number[][]>>().toEqualTypeOf<number>();
+        expectTypeOf<utilities.FlattenArrayType<number[][][]>>().toEqualTypeOf<number>();
+        expectTypeOf<utilities.FlattenArrayType<string[][][][]>>().toEqualTypeOf<string>();
+        expectTypeOf<utilities.FlattenArrayType<unknown[][][][]>>().toEqualTypeOf<unknown>();
+    });
 });

--- a/test/string-mappers.test.ts
+++ b/test/string-mappers.test.ts
@@ -2,147 +2,147 @@ import { describe, test, expectTypeOf } from "vitest";
 import type * as utilities from "../src/string-mappers";
 
 describe("String mappers", () => {
-	test("TrimLeft", () => {
-		expectTypeOf<utilities.TrimLeft<"  foo">>().toMatchTypeOf<"foo">();
-		expectTypeOf<utilities.TrimLeft<"   foo bar">>().toMatchTypeOf<"foo bar">();
-		expectTypeOf<utilities.TrimLeft<"\r\r\r\nfoo bar">>().toMatchTypeOf<"foo bar">();
-	});
+    test("TrimLeft", () => {
+        expectTypeOf<utilities.TrimLeft<"  foo">>().toMatchTypeOf<"foo">();
+        expectTypeOf<utilities.TrimLeft<"   foo bar">>().toMatchTypeOf<"foo bar">();
+        expectTypeOf<utilities.TrimLeft<"\r\r\r\nfoo bar">>().toMatchTypeOf<"foo bar">();
+    });
 
-	test("TrimRight", () => {
-		expectTypeOf<utilities.TrimRight<"foo  ">>().toMatchTypeOf<"foo">();
-		expectTypeOf<utilities.TrimRight<"foo bar  ">>().toMatchTypeOf<"foo bar">();
-		expectTypeOf<utilities.TrimRight<"foo bar  \n\n">>().toMatchTypeOf<"foo bar">();
-	});
+    test("TrimRight", () => {
+        expectTypeOf<utilities.TrimRight<"foo  ">>().toMatchTypeOf<"foo">();
+        expectTypeOf<utilities.TrimRight<"foo bar  ">>().toMatchTypeOf<"foo bar">();
+        expectTypeOf<utilities.TrimRight<"foo bar  \n\n">>().toMatchTypeOf<"foo bar">();
+    });
 
-	test("Trim", () => {
-		expectTypeOf<utilities.Trim<"  foo">>().toMatchTypeOf<"foo">();
-		expectTypeOf<utilities.Trim<"foo  ">>().toMatchTypeOf<"foo">();
-		expectTypeOf<utilities.Trim<"  foo  ">>().toMatchTypeOf<"foo">();
-		expectTypeOf<utilities.Trim<"\r\n foo \r\n">>().toMatchTypeOf<"foo">();
-	});
+    test("Trim", () => {
+        expectTypeOf<utilities.Trim<"  foo">>().toMatchTypeOf<"foo">();
+        expectTypeOf<utilities.Trim<"foo  ">>().toMatchTypeOf<"foo">();
+        expectTypeOf<utilities.Trim<"  foo  ">>().toMatchTypeOf<"foo">();
+        expectTypeOf<utilities.Trim<"\r\n foo \r\n">>().toMatchTypeOf<"foo">();
+    });
 
-	test("Uppercase", () => {
-		expectTypeOf<utilities.Uppercase<"foo">>().toMatchTypeOf<"FOO">();
-		expectTypeOf<utilities.Uppercase<"Foo">>().toMatchTypeOf<"FOO">();
-		expectTypeOf<utilities.Uppercase<"Foo bar">>().toMatchTypeOf<"FOO BAR">();
-		expectTypeOf<utilities.Uppercase<"Foo Bar">>().toMatchTypeOf<"FOO BAR">();
-	});
+    test("Uppercase", () => {
+        expectTypeOf<utilities.Uppercase<"foo">>().toMatchTypeOf<"FOO">();
+        expectTypeOf<utilities.Uppercase<"Foo">>().toMatchTypeOf<"FOO">();
+        expectTypeOf<utilities.Uppercase<"Foo bar">>().toMatchTypeOf<"FOO BAR">();
+        expectTypeOf<utilities.Uppercase<"Foo Bar">>().toMatchTypeOf<"FOO BAR">();
+    });
 
-	test("Lowercase", () => {
-		expectTypeOf<utilities.Lowercase<"foo">>().toMatchTypeOf<"foo">();
-		expectTypeOf<utilities.Lowercase<"Foo">>().toMatchTypeOf<"foo">();
-		expectTypeOf<utilities.Lowercase<"Foo bar">>().toMatchTypeOf<"foo bar">();
-		expectTypeOf<utilities.Lowercase<"Foo Bar">>().toMatchTypeOf<"foo bar">();
-	});
+    test("Lowercase", () => {
+        expectTypeOf<utilities.Lowercase<"foo">>().toMatchTypeOf<"foo">();
+        expectTypeOf<utilities.Lowercase<"Foo">>().toMatchTypeOf<"foo">();
+        expectTypeOf<utilities.Lowercase<"Foo bar">>().toMatchTypeOf<"foo bar">();
+        expectTypeOf<utilities.Lowercase<"Foo Bar">>().toMatchTypeOf<"foo bar">();
+    });
 
-	test("Capitalize the strings", () => {
-		expectTypeOf<utilities.Capitalize<"foo">>().toMatchTypeOf<"Foo">();
-		expectTypeOf<utilities.Capitalize<"foo bar">>().toMatchTypeOf<"Foo Bar">();
-		expectTypeOf<utilities.Capitalize<"Foo">>().toMatchTypeOf<"Foo">();
-		expectTypeOf<utilities.Capitalize<"Foo bar">>().toMatchTypeOf<"Foo Bar">();
-		expectTypeOf<utilities.Capitalize<"Foo Bar">>().toMatchTypeOf<"Foo Bar">();
-	});
+    test("Capitalize the strings", () => {
+        expectTypeOf<utilities.Capitalize<"foo">>().toMatchTypeOf<"Foo">();
+        expectTypeOf<utilities.Capitalize<"foo bar">>().toMatchTypeOf<"Foo Bar">();
+        expectTypeOf<utilities.Capitalize<"Foo">>().toMatchTypeOf<"Foo">();
+        expectTypeOf<utilities.Capitalize<"Foo bar">>().toMatchTypeOf<"Foo Bar">();
+        expectTypeOf<utilities.Capitalize<"Foo Bar">>().toMatchTypeOf<"Foo Bar">();
+    });
 });
 
 describe("Join", () => {
-	test("Join the elements of a tuple separated by a character", () => {});
-	expectTypeOf<utilities.Join<["a", "p", "p", "l", "e"], "-">>().toEqualTypeOf<"a-p-p-l-e">();
-	expectTypeOf<utilities.Join<["Hello", "World"], " ">>().toEqualTypeOf<"Hello World">();
-	expectTypeOf<utilities.Join<["2", "2", "2"], "1">>().toEqualTypeOf<"21212">();
+    test("Join the elements of a tuple separated by a character", () => {});
+    expectTypeOf<utilities.Join<["a", "p", "p", "l", "e"], "-">>().toEqualTypeOf<"a-p-p-l-e">();
+    expectTypeOf<utilities.Join<["Hello", "World"], " ">>().toEqualTypeOf<"Hello World">();
+    expectTypeOf<utilities.Join<["2", "2", "2"], "1">>().toEqualTypeOf<"21212">();
 });
 
 describe("Match strings", () => {
-	test("StartsWith", () => {
-		expectTypeOf<utilities.StartsWith<"foobar", "foo">>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.StartsWith<"foobar", "bar">>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.StartsWith<"foobar", "obar">>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.StartsWith<"foobar", "foobarr">>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.StartsWith<"foobar", "">>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.StartsWith<"", "">>().toEqualTypeOf<true>();
-	});
+    test("StartsWith", () => {
+        expectTypeOf<utilities.StartsWith<"foobar", "foo">>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.StartsWith<"foobar", "bar">>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.StartsWith<"foobar", "obar">>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.StartsWith<"foobar", "foobarr">>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.StartsWith<"foobar", "">>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.StartsWith<"", "">>().toEqualTypeOf<true>();
+    });
 
-	test("EndsWith", () => {
-		expectTypeOf<utilities.EndsWith<"foobar", "foo">>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.EndsWith<"foobar", "bar">>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.EndsWith<"bar", "br">>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.EndsWith<"foobar", " ">>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.EndsWith<"foobar", "">>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.EndsWith<"", "">>().toEqualTypeOf<true>();
-	});
+    test("EndsWith", () => {
+        expectTypeOf<utilities.EndsWith<"foobar", "foo">>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.EndsWith<"foobar", "bar">>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.EndsWith<"bar", "br">>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.EndsWith<"foobar", " ">>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.EndsWith<"foobar", "">>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.EndsWith<"", "">>().toEqualTypeOf<true>();
+    });
 });
 
 describe("DropChar", () => {
-	test("Remove the characters that match with the given char", () => {
-		expectTypeOf<utilities.DropChar<"foobar foo!", " ">>().toEqualTypeOf<"foobarfoo!">();
-		expectTypeOf<utilities.DropChar<"f o o b a r f o o !", " ">>().toEqualTypeOf<"foobarfoo!">();
-		expectTypeOf<utilities.DropChar<"f o o b a r f o o !", any>>().toEqualTypeOf<"">();
-	});
+    test("Remove the characters that match with the given char", () => {
+        expectTypeOf<utilities.DropChar<"foobar foo!", " ">>().toEqualTypeOf<"foobarfoo!">();
+        expectTypeOf<utilities.DropChar<"f o o b a r f o o !", " ">>().toEqualTypeOf<"foobarfoo!">();
+        expectTypeOf<utilities.DropChar<"f o o b a r f o o !", any>>().toEqualTypeOf<"">();
+    });
 });
 
 describe("LengthOfString", () => {
-	test("Returns the length of a string type", () => {
-		expectTypeOf<utilities.LengthOfString<"">>().toEqualTypeOf<0>();
-		expectTypeOf<utilities.LengthOfString<any>>().toEqualTypeOf<0>();
-		expectTypeOf<utilities.LengthOfString<never>>().toEqualTypeOf<never>();
-		expectTypeOf<utilities.LengthOfString<"foobarfoobar">>().toEqualTypeOf<12>();
-	});
+    test("Returns the length of a string type", () => {
+        expectTypeOf<utilities.LengthOfString<"">>().toEqualTypeOf<0>();
+        expectTypeOf<utilities.LengthOfString<any>>().toEqualTypeOf<0>();
+        expectTypeOf<utilities.LengthOfString<never>>().toEqualTypeOf<never>();
+        expectTypeOf<utilities.LengthOfString<"foobarfoobar">>().toEqualTypeOf<12>();
+    });
 });
 
 describe("IndexOfString", () => {
-	test("Returns the first index occurrence of a character", () => {
-		expectTypeOf<utilities.IndexOfString<"", never>>().toEqualTypeOf<-1>();
-		expectTypeOf<utilities.IndexOfString<"foobar", "f">>().toEqualTypeOf<0>();
-		expectTypeOf<utilities.IndexOfString<"foobar", "b">>().toEqualTypeOf<3>();
-		expectTypeOf<utilities.IndexOfString<"foobar", "r">>().toEqualTypeOf<5>();
-		expectTypeOf<utilities.IndexOfString<"foobar", "x">>().toEqualTypeOf<-1>();
-	});
+    test("Returns the first index occurrence of a character", () => {
+        expectTypeOf<utilities.IndexOfString<"", never>>().toEqualTypeOf<-1>();
+        expectTypeOf<utilities.IndexOfString<"foobar", "f">>().toEqualTypeOf<0>();
+        expectTypeOf<utilities.IndexOfString<"foobar", "b">>().toEqualTypeOf<3>();
+        expectTypeOf<utilities.IndexOfString<"foobar", "r">>().toEqualTypeOf<5>();
+        expectTypeOf<utilities.IndexOfString<"foobar", "x">>().toEqualTypeOf<-1>();
+    });
 });
 
 describe("FirstUniqueCharIndex", () => {
-	test("Returns the first index of a character that is not repeated", () => {
-		expectTypeOf<utilities.FirstUniqueCharIndex<"">>().toEqualTypeOf<-1>();
-		expectTypeOf<utilities.FirstUniqueCharIndex<"comparator">>().toEqualTypeOf<0>();
-		expectTypeOf<utilities.FirstUniqueCharIndex<"comparator and comparable">>().toEqualTypeOf<7>();
-		expectTypeOf<utilities.FirstUniqueCharIndex<"aabbcc">>().toEqualTypeOf<-1>();
-		expectTypeOf<utilities.FirstUniqueCharIndex<"aabcb">>().toEqualTypeOf<3>();
-	});
+    test("Returns the first index of a character that is not repeated", () => {
+        expectTypeOf<utilities.FirstUniqueCharIndex<"">>().toEqualTypeOf<-1>();
+        expectTypeOf<utilities.FirstUniqueCharIndex<"comparator">>().toEqualTypeOf<0>();
+        expectTypeOf<utilities.FirstUniqueCharIndex<"comparator and comparable">>().toEqualTypeOf<7>();
+        expectTypeOf<utilities.FirstUniqueCharIndex<"aabbcc">>().toEqualTypeOf<-1>();
+        expectTypeOf<utilities.FirstUniqueCharIndex<"aabcb">>().toEqualTypeOf<3>();
+    });
 });
 
 describe("Replace", () => {
-	test("Replace the first match with a new value", () => {
-		expectTypeOf<utilities.Replace<"foobar", "bar", "foo">>().toEqualTypeOf<"foofoo">();
-		expectTypeOf<utilities.Replace<"foobarbar", "bar", "foo">>().toEqualTypeOf<"foofoobar">();
-		expectTypeOf<utilities.Replace<"foobarbar", "", "foo">>().toEqualTypeOf<"foobarbar">();
-		expectTypeOf<utilities.Replace<"foobarbar", "bar", "">>().toEqualTypeOf<"foobar">();
-	});
+    test("Replace the first match with a new value", () => {
+        expectTypeOf<utilities.Replace<"foobar", "bar", "foo">>().toEqualTypeOf<"foofoo">();
+        expectTypeOf<utilities.Replace<"foobarbar", "bar", "foo">>().toEqualTypeOf<"foofoobar">();
+        expectTypeOf<utilities.Replace<"foobarbar", "", "foo">>().toEqualTypeOf<"foobarbar">();
+        expectTypeOf<utilities.Replace<"foobarbar", "bar", "">>().toEqualTypeOf<"foobar">();
+    });
 });
 
 describe("CheckRepeatedChars", () => {
-	test("Check if there are repeated characters in the string", () => {
-		expectTypeOf<utilities.CheckRepeatedChars<"">>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.CheckRepeatedChars<"aba">>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.CheckRepeatedChars<"abcza">>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.CheckRepeatedChars<"añlamnhj">>().toEqualTypeOf<true>();
-	});
+    test("Check if there are repeated characters in the string", () => {
+        expectTypeOf<utilities.CheckRepeatedChars<"">>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.CheckRepeatedChars<"aba">>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.CheckRepeatedChars<"abcza">>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.CheckRepeatedChars<"añlamnhj">>().toEqualTypeOf<true>();
+    });
 });
 
 describe("ParseUrlParams", () => {
-	test("Parse the URL parameters", () => {
-		expectTypeOf<utilities.ParseUrlParams<"posts/:id">>().toEqualTypeOf<"id">();
-		expectTypeOf<utilities.ParseUrlParams<":posts/:id">>().toEqualTypeOf<"posts" | "id">();
-		expectTypeOf<utilities.ParseUrlParams<"user/:id/posts/:postId">>().toEqualTypeOf<"id" | "postId">();
-		expectTypeOf<utilities.ParseUrlParams<":posts/:id">>().toEqualTypeOf<"posts" | "id">();
-		expectTypeOf<utilities.ParseUrlParams<"posts/:id/:items/likes">>().toEqualTypeOf<"id" | "items">();
-	});
+    test("Parse the URL parameters", () => {
+        expectTypeOf<utilities.ParseUrlParams<"posts/:id">>().toEqualTypeOf<"id">();
+        expectTypeOf<utilities.ParseUrlParams<":posts/:id">>().toEqualTypeOf<"posts" | "id">();
+        expectTypeOf<utilities.ParseUrlParams<"user/:id/posts/:postId">>().toEqualTypeOf<"id" | "postId">();
+        expectTypeOf<utilities.ParseUrlParams<":posts/:id">>().toEqualTypeOf<"posts" | "id">();
+        expectTypeOf<utilities.ParseUrlParams<"posts/:id/:items/likes">>().toEqualTypeOf<"id" | "items">();
+    });
 });
 
 describe("FindAll", () => {
-	test("Find all the indexes of a substring in a string", () => {
-		expectTypeOf<utilities.FindAll<"", "">>().toEqualTypeOf<[]>();
-		expectTypeOf<utilities.FindAll<"ooooo", "">>().toEqualTypeOf<[]>();
-		expectTypeOf<utilities.FindAll<"", "foobar">>().toEqualTypeOf<[]>();
-		expectTypeOf<utilities.FindAll<"foobar", "o">>().toEqualTypeOf<[1, 2]>();
-		expectTypeOf<utilities.FindAll<"foooo", "o">>().toEqualTypeOf<[1, 2, 3, 4]>();
-		expectTypeOf<utilities.FindAll<"ooooo", "oo">>().toEqualTypeOf<[0, 1, 2, 3]>();
-	});
+    test("Find all the indexes of a substring in a string", () => {
+        expectTypeOf<utilities.FindAll<"", "">>().toEqualTypeOf<[]>();
+        expectTypeOf<utilities.FindAll<"ooooo", "">>().toEqualTypeOf<[]>();
+        expectTypeOf<utilities.FindAll<"", "foobar">>().toEqualTypeOf<[]>();
+        expectTypeOf<utilities.FindAll<"foobar", "o">>().toEqualTypeOf<[1, 2]>();
+        expectTypeOf<utilities.FindAll<"foooo", "o">>().toEqualTypeOf<[1, 2, 3, 4]>();
+        expectTypeOf<utilities.FindAll<"ooooo", "oo">>().toEqualTypeOf<[0, 1, 2, 3]>();
+    });
 });

--- a/test/type-guards.test.ts
+++ b/test/type-guards.test.ts
@@ -2,25 +2,25 @@ import { describe, test, expectTypeOf } from "vitest";
 import type { IsNever, IsOdd } from "../src/type-guards";
 
 describe("Utility types for type guards", () => {
-	describe("IsNever", () => {
-		test("should return false for non-never types", () => {
-			expectTypeOf<IsNever<string>>().toEqualTypeOf<false>();
-			expectTypeOf<IsNever<number>>().toEqualTypeOf<false>();
-		});
+    describe("IsNever", () => {
+        test("should return false for non-never types", () => {
+            expectTypeOf<IsNever<string>>().toEqualTypeOf<false>();
+            expectTypeOf<IsNever<number>>().toEqualTypeOf<false>();
+        });
 
-		test("should return true for never type", () => {
-			expectTypeOf<IsNever<never>>().toEqualTypeOf<true>();
-		});
-	});
+        test("should return true for never type", () => {
+            expectTypeOf<IsNever<never>>().toEqualTypeOf<true>();
+        });
+    });
 
-	describe("IsOdd", () => {
-		test("Check if a number is odd", () => {
-			expectTypeOf<IsOdd<0>>().toEqualTypeOf<false>();
-			expectTypeOf<IsOdd<2023>>().toEqualTypeOf<true>();
-			expectTypeOf<IsOdd<2024>>().toEqualTypeOf<false>();
-			expectTypeOf<IsOdd<number>>().toEqualTypeOf<false>();
-			expectTypeOf<IsOdd<1234567891>>().toEqualTypeOf<true>();
-			expectTypeOf<IsOdd<1234567892>>().toEqualTypeOf<false>();
-		});
-	});
+    describe("IsOdd", () => {
+        test("Check if a number is odd", () => {
+            expectTypeOf<IsOdd<0>>().toEqualTypeOf<false>();
+            expectTypeOf<IsOdd<2023>>().toEqualTypeOf<true>();
+            expectTypeOf<IsOdd<2024>>().toEqualTypeOf<false>();
+            expectTypeOf<IsOdd<number>>().toEqualTypeOf<false>();
+            expectTypeOf<IsOdd<1234567891>>().toEqualTypeOf<true>();
+            expectTypeOf<IsOdd<1234567892>>().toEqualTypeOf<false>();
+        });
+    });
 });

--- a/test/utility-type.test.ts
+++ b/test/utility-type.test.ts
@@ -3,384 +3,384 @@ import { describe, test, expectTypeOf } from "vitest";
 import type * as utilities from "../src/object-types";
 
 describe("Readonly", () => {
-	test("DeepReadonly for objects", () => {
-		expectTypeOf<utilities.DeepReadonly<{ foo: string; bar: number }>>().toEqualTypeOf<{
-			readonly foo: string;
-			readonly bar: number;
-		}>();
-		expectTypeOf<utilities.DeepReadonly<{ foo: string; bar: { foo: number } }>>().toEqualTypeOf<{
-			readonly foo: string;
-			readonly bar: { readonly foo: number };
-		}>();
-		expectTypeOf<utilities.DeepReadonly<{ foo: { bar: string }; bar: { foo: number } }>>().toEqualTypeOf<{
-			readonly foo: { readonly bar: string };
-			readonly bar: { readonly foo: number };
-		}>();
-	});
+    test("DeepReadonly for objects", () => {
+        expectTypeOf<utilities.DeepReadonly<{ foo: string; bar: number }>>().toEqualTypeOf<{
+            readonly foo: string;
+            readonly bar: number;
+        }>();
+        expectTypeOf<utilities.DeepReadonly<{ foo: string; bar: { foo: number } }>>().toEqualTypeOf<{
+            readonly foo: string;
+            readonly bar: { readonly foo: number };
+        }>();
+        expectTypeOf<utilities.DeepReadonly<{ foo: { bar: string }; bar: { foo: number } }>>().toEqualTypeOf<{
+            readonly foo: { readonly bar: string };
+            readonly bar: { readonly foo: number };
+        }>();
+    });
 });
 
 describe("Properties with keyof", () => {
-	test("Combines keys of two object types", () => {
-		expectTypeOf<utilities.Properties<{ a: number }, { a: string }>>().toEqualTypeOf<"a">();
-		expectTypeOf<utilities.Properties<{ a: number }, { b: string }>>().toEqualTypeOf<"a" | "b">();
-		expectTypeOf<utilities.Properties<{ a: number }, { b: string; c: number }>>().toEqualTypeOf<"a" | "b" | "c">();
-	});
+    test("Combines keys of two object types", () => {
+        expectTypeOf<utilities.Properties<{ a: number }, { a: string }>>().toEqualTypeOf<"a">();
+        expectTypeOf<utilities.Properties<{ a: number }, { b: string }>>().toEqualTypeOf<"a" | "b">();
+        expectTypeOf<utilities.Properties<{ a: number }, { b: string; c: number }>>().toEqualTypeOf<"a" | "b" | "c">();
+    });
 });
 
 describe("Merge values", () => {
-	test("Union two object types", () => {
-		expectTypeOf<utilities.Merge<{ a: number }, { b: string }>>().toEqualTypeOf<{
-			a: number;
-			b: string;
-		}>();
-		expectTypeOf<utilities.Merge<{ a: number }, { b: string; c: boolean }>>().toEqualTypeOf<{
-			a: number;
-			b: string;
-			c: boolean;
-		}>();
-		expectTypeOf<utilities.Merge<{ a: number }, { a: string; b: string }>>().toEqualTypeOf<{ a: string; b: string }>();
-	});
+    test("Union two object types", () => {
+        expectTypeOf<utilities.Merge<{ a: number }, { b: string }>>().toEqualTypeOf<{
+            a: number;
+            b: string;
+        }>();
+        expectTypeOf<utilities.Merge<{ a: number }, { b: string; c: boolean }>>().toEqualTypeOf<{
+            a: number;
+            b: string;
+            c: boolean;
+        }>();
+        expectTypeOf<utilities.Merge<{ a: number }, { a: string; b: string }>>().toEqualTypeOf<{ a: string; b: string }>();
+    });
 });
 
 describe("FlattenProperties", () => {
-	test("Extract property from object", () => {
-		expectTypeOf<utilities.FlattenProperties<{ name: string; address: { street: string } }, "address">>().toEqualTypeOf<{
-			name: string;
-			street: string;
-		}>();
-		expectTypeOf<
-			utilities.FlattenProperties<{ name: string; address: { street: string; avenue: string } }, "address">
-		>().toEqualTypeOf<{ name: string; street: string; avenue: string }>();
-	});
+    test("Extract property from object", () => {
+        expectTypeOf<utilities.FlattenProperties<{ name: string; address: { street: string } }, "address">>().toEqualTypeOf<{
+            name: string;
+            street: string;
+        }>();
+        expectTypeOf<
+            utilities.FlattenProperties<{ name: string; address: { street: string; avenue: string } }, "address">
+        >().toEqualTypeOf<{ name: string; street: string; avenue: string }>();
+    });
 });
 
 describe("PublicOnly", () => {
-	test("Remove properties beginning with (_)", () => {
-		expectTypeOf<utilities.PublicOnly<{ foo: string }>>().toEqualTypeOf<{
-			foo: string;
-		}>();
-		expectTypeOf<utilities.PublicOnly<{ foo: string; _bar: string }>>().toEqualTypeOf<{ foo: string }>();
-		expectTypeOf<utilities.PublicOnly<{ _foo: string; _bar: string }>>().toEqualTypeOf<{}>();
-	});
+    test("Remove properties beginning with (_)", () => {
+        expectTypeOf<utilities.PublicOnly<{ foo: string }>>().toEqualTypeOf<{
+            foo: string;
+        }>();
+        expectTypeOf<utilities.PublicOnly<{ foo: string; _bar: string }>>().toEqualTypeOf<{ foo: string }>();
+        expectTypeOf<utilities.PublicOnly<{ _foo: string; _bar: string }>>().toEqualTypeOf<{}>();
+    });
 });
 
 describe("RetrieveKeyValue", () => {
-	test("Exist the key within objects", () => {
-		expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { bar: number }, "foo">>().toEqualTypeOf<string>();
-		expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { bar: number }, "bar">>().toEqualTypeOf<number>();
-		expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { foo: number }, "foo">>().toEqualTypeOf<string>();
-		expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { foo: number }, "foobar">>().toEqualTypeOf<never>();
-	});
+    test("Exist the key within objects", () => {
+        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { bar: number }, "foo">>().toEqualTypeOf<string>();
+        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { bar: number }, "bar">>().toEqualTypeOf<number>();
+        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { foo: number }, "foo">>().toEqualTypeOf<string>();
+        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { foo: number }, "foobar">>().toEqualTypeOf<never>();
+    });
 });
 
 describe("RequiredByKeys", () => {
-	test("Convert required properties in an object", () => {
-		expectTypeOf<utilities.RequiredByKeys<{ foo?: string; bar?: number }, "foo">>().toEqualTypeOf<{
-			foo: string;
-			bar?: number;
-		}>();
-		expectTypeOf<utilities.RequiredByKeys<{ foo?: string; bar?: number }, "bar">>().toEqualTypeOf<{
-			foo?: string;
-			bar: number;
-		}>();
-		expectTypeOf<utilities.RequiredByKeys<{ foo?: string; bar?: number }>>().toEqualTypeOf<{ foo: string; bar: number }>();
-	});
+    test("Convert required properties in an object", () => {
+        expectTypeOf<utilities.RequiredByKeys<{ foo?: string; bar?: number }, "foo">>().toEqualTypeOf<{
+            foo: string;
+            bar?: number;
+        }>();
+        expectTypeOf<utilities.RequiredByKeys<{ foo?: string; bar?: number }, "bar">>().toEqualTypeOf<{
+            foo?: string;
+            bar: number;
+        }>();
+        expectTypeOf<utilities.RequiredByKeys<{ foo?: string; bar?: number }>>().toEqualTypeOf<{ foo: string; bar: number }>();
+    });
 });
 
 describe("UnionMerge", () => {
-	test("Merge the types of the properties of two objects.", () => {
-		expectTypeOf<utilities.UnionMerge<{ foo: string }, { bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
-		expectTypeOf<utilities.UnionMerge<{ foo: string }, { foo: number }>>().toEqualTypeOf<{ foo: string | number }>();
-		expectTypeOf<utilities.UnionMerge<{ foo: string | number }, { foo: boolean }>>().toEqualTypeOf<{
-			foo: string | number | boolean;
-		}>();
-	});
+    test("Merge the types of the properties of two objects.", () => {
+        expectTypeOf<utilities.UnionMerge<{ foo: string }, { bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
+        expectTypeOf<utilities.UnionMerge<{ foo: string }, { foo: number }>>().toEqualTypeOf<{ foo: string | number }>();
+        expectTypeOf<utilities.UnionMerge<{ foo: string | number }, { foo: boolean }>>().toEqualTypeOf<{
+            foo: string | number | boolean;
+        }>();
+    });
 });
 
 describe("Mutable", () => {
-	test("Converts properties to non readonly only one level", () => {
-		expectTypeOf<utilities.Mutable<{ readonly foo: string }>>().toEqualTypeOf<{
-			foo: string;
-		}>();
-		expectTypeOf<
-			utilities.Mutable<{
-				readonly foo: string;
-				readonly bar: { readonly foobar: number };
-			}>
-		>().toEqualTypeOf<{ foo: string; bar: { readonly foobar: number } }>();
-	});
+    test("Converts properties to non readonly only one level", () => {
+        expectTypeOf<utilities.Mutable<{ readonly foo: string }>>().toEqualTypeOf<{
+            foo: string;
+        }>();
+        expectTypeOf<
+            utilities.Mutable<{
+                readonly foo: string;
+                readonly bar: { readonly foobar: number };
+            }>
+        >().toEqualTypeOf<{ foo: string; bar: { readonly foobar: number } }>();
+    });
 });
 
 describe("DeepMutable", () => {
-	test("Converts all properties to non readonly of an object type", () => {
-		interface Test5 {
-			foo: [
-				{ bar: string },
-				{
-					foobar: {
-						foofoo: number;
-					};
-				},
-			];
-		}
+    test("Converts all properties to non readonly of an object type", () => {
+        interface Test5 {
+            foo: [
+                { bar: string },
+                {
+                    foobar: {
+                        foofoo: number;
+                    };
+                },
+            ];
+        }
 
-		interface Test6 {
-			foo: {
-				bar: [
-					{
-						foobar: string;
-						barfoo: {
-							foofoo: number;
-						};
-					},
-				];
-			};
-		}
-		expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: string }>>>().toEqualTypeOf<{ foo: string }>();
-		expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: { bar: number } }>>>().toEqualTypeOf<{
-			foo: { bar: number };
-		}>();
-		expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: { bar: { foobar: number } } }>>>().toEqualTypeOf<{
-			foo: { bar: { foobar: number } };
-		}>();
-		expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: [{ bar: string; foobar: number }] }>>>().toEqualTypeOf<{
-			foo: [{ bar: string; foobar: number }];
-		}>();
-		expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test5>>>().toEqualTypeOf<Test5>();
-		expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test6>>>().toEqualTypeOf<Test6>();
-	});
+        interface Test6 {
+            foo: {
+                bar: [
+                    {
+                        foobar: string;
+                        barfoo: {
+                            foofoo: number;
+                        };
+                    },
+                ];
+            };
+        }
+        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: string }>>>().toEqualTypeOf<{ foo: string }>();
+        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: { bar: number } }>>>().toEqualTypeOf<{
+            foo: { bar: number };
+        }>();
+        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: { bar: { foobar: number } } }>>>().toEqualTypeOf<{
+            foo: { bar: { foobar: number } };
+        }>();
+        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: [{ bar: string; foobar: number }] }>>>().toEqualTypeOf<{
+            foo: [{ bar: string; foobar: number }];
+        }>();
+        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test5>>>().toEqualTypeOf<Test5>();
+        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test6>>>().toEqualTypeOf<Test6>();
+    });
 });
 
 describe("MergeAll", () => {
-	test("Merge the properties of a tuple of objects", () => {
-		expectTypeOf<utilities.MergeAll<[{ foo: string }, { bar: number }]>>().toEqualTypeOf<{ foo: string; bar: number }>();
-		expectTypeOf<utilities.MergeAll<[{ foo: string }, { bar: { foobar: number } }]>>().toEqualTypeOf<{
-			foo: string;
-			bar: { foobar: number };
-		}>();
-		type Expect3 = {
-			foo: string | boolean;
-			bar: number | string;
-			foobar: string;
-		};
-		expectTypeOf<
-			utilities.MergeAll<[{ foo: string }, { bar: string }, { bar: number; foo: boolean; foobar: string }]>
-		>().toEqualTypeOf<Expect3>();
-	});
+    test("Merge the properties of a tuple of objects", () => {
+        expectTypeOf<utilities.MergeAll<[{ foo: string }, { bar: number }]>>().toEqualTypeOf<{ foo: string; bar: number }>();
+        expectTypeOf<utilities.MergeAll<[{ foo: string }, { bar: { foobar: number } }]>>().toEqualTypeOf<{
+            foo: string;
+            bar: { foobar: number };
+        }>();
+        type Expect3 = {
+            foo: string | boolean;
+            bar: number | string;
+            foobar: string;
+        };
+        expectTypeOf<
+            utilities.MergeAll<[{ foo: string }, { bar: string }, { bar: number; foo: boolean; foobar: string }]>
+        >().toEqualTypeOf<Expect3>();
+    });
 });
 
 describe("ToUnion", () => {
-	test("Create an union type", () => {
-		expectTypeOf<utilities.ToUnion<12>>().toEqualTypeOf<12>();
-		expectTypeOf<utilities.ToUnion<"foo">>().toEqualTypeOf<"foo">();
-		expectTypeOf<utilities.ToUnion<12 | 21>>().toEqualTypeOf<12 | 21>();
-		expectTypeOf<utilities.ToUnion<[12, 21, "foo"]>>().toEqualTypeOf<12 | 21 | "foo" | []>();
-	});
+    test("Create an union type", () => {
+        expectTypeOf<utilities.ToUnion<12>>().toEqualTypeOf<12>();
+        expectTypeOf<utilities.ToUnion<"foo">>().toEqualTypeOf<"foo">();
+        expectTypeOf<utilities.ToUnion<12 | 21>>().toEqualTypeOf<12 | 21>();
+        expectTypeOf<utilities.ToUnion<[12, 21, "foo"]>>().toEqualTypeOf<12 | 21 | "foo" | []>();
+    });
 });
 
 describe("AddPropertyToObject", () => {
-	test("Append a new property of an exist object type", () => {
-		expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", number>>().toEqualTypeOf<{
-			foo: string;
-			bar: number;
-		}>();
-		expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", { foobar: number; barfoo: boolean }>>().toEqualTypeOf<{
-			foo: string;
-			bar: { foobar: number; barfoo: boolean };
-		}>();
-		expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", [1, 2, 3]>>().toEqualTypeOf<{
-			foo: string;
-			bar: [1, 2, 3];
-		}>();
-		expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", string | boolean | number>>().toEqualTypeOf<{
-			foo: string;
-			bar: string | boolean | number;
-		}>();
-	});
+    test("Append a new property of an exist object type", () => {
+        expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", number>>().toEqualTypeOf<{
+            foo: string;
+            bar: number;
+        }>();
+        expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", { foobar: number; barfoo: boolean }>>().toEqualTypeOf<{
+            foo: string;
+            bar: { foobar: number; barfoo: boolean };
+        }>();
+        expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", [1, 2, 3]>>().toEqualTypeOf<{
+            foo: string;
+            bar: [1, 2, 3];
+        }>();
+        expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", string | boolean | number>>().toEqualTypeOf<{
+            foo: string;
+            bar: string | boolean | number;
+        }>();
+    });
 });
 
 describe("Intersection", () => {
-	test("Intersection of properties between two objects", () => {
-		expectTypeOf<utilities.Intersection<{ foo: string }, { foo: number; bar: boolean }>>().toEqualTypeOf<{ bar: boolean }>();
-		expectTypeOf<utilities.Intersection<{ foo: string; bar: boolean }, { bar: number; foo: bigint }>>().toEqualTypeOf<{}>();
-		expectTypeOf<
-			utilities.Intersection<{ foo: string; bar: { bar: number } }, { barfoo: { bar: number }; foo: bigint }>
-		>().toEqualTypeOf<{ bar: { bar: number }; barfoo: { bar: number } }>();
-	});
+    test("Intersection of properties between two objects", () => {
+        expectTypeOf<utilities.Intersection<{ foo: string }, { foo: number; bar: boolean }>>().toEqualTypeOf<{ bar: boolean }>();
+        expectTypeOf<utilities.Intersection<{ foo: string; bar: boolean }, { bar: number; foo: bigint }>>().toEqualTypeOf<{}>();
+        expectTypeOf<
+            utilities.Intersection<{ foo: string; bar: { bar: number } }, { barfoo: { bar: number }; foo: bigint }>
+        >().toEqualTypeOf<{ bar: { bar: number }; barfoo: { bar: number } }>();
+    });
 });
 
 describe("Omit Properties", () => {
-	describe("Omit", () => {
-		test("Omit the properties based on the key type", () => {
-			expectTypeOf<Omit<{ foo: string }, "">>().toEqualTypeOf<{
-				foo: string;
-			}>();
-			expectTypeOf<Omit<{ foo: string; bar: number }, "foo">>().toEqualTypeOf<{ bar: number }>();
-			expectTypeOf<Omit<{ foo: () => void; bar: { foobar: number } }, "foo">>().toEqualTypeOf<{
-				bar: { foobar: number };
-			}>();
-		});
-	});
+    describe("Omit", () => {
+        test("Omit the properties based on the key type", () => {
+            expectTypeOf<Omit<{ foo: string }, "">>().toEqualTypeOf<{
+                foo: string;
+            }>();
+            expectTypeOf<Omit<{ foo: string; bar: number }, "foo">>().toEqualTypeOf<{ bar: number }>();
+            expectTypeOf<Omit<{ foo: () => void; bar: { foobar: number } }, "foo">>().toEqualTypeOf<{
+                bar: { foobar: number };
+            }>();
+        });
+    });
 
-	describe("OmitByType", () => {
-		test("Omit the properties based on the type", () => {
-			expectTypeOf<utilities.OmitByType<{ foo: string; bar: string; foobar: number }, string>>().toEqualTypeOf<{
-				foobar: number;
-			}>();
-			expectTypeOf<utilities.OmitByType<{ foo: string; bar: number; foobar: boolean }, string | boolean>>().toEqualTypeOf<{
-				bar: number;
-			}>();
-			expectTypeOf<
-				utilities.OmitByType<
-					{
-						foo: () => void;
-						bar: () => void;
-						foobar: { barbar: number };
-					},
-					() => void
-				>
-			>().toEqualTypeOf<{ foobar: { barbar: number } }>();
-		});
-	});
+    describe("OmitByType", () => {
+        test("Omit the properties based on the type", () => {
+            expectTypeOf<utilities.OmitByType<{ foo: string; bar: string; foobar: number }, string>>().toEqualTypeOf<{
+                foobar: number;
+            }>();
+            expectTypeOf<utilities.OmitByType<{ foo: string; bar: number; foobar: boolean }, string | boolean>>().toEqualTypeOf<{
+                bar: number;
+            }>();
+            expectTypeOf<
+                utilities.OmitByType<
+                    {
+                        foo: () => void;
+                        bar: () => void;
+                        foobar: { barbar: number };
+                    },
+                    () => void
+                >
+            >().toEqualTypeOf<{ foobar: { barbar: number } }>();
+        });
+    });
 });
 
 describe("Parameters", () => {
-	test("Returns the parameters of a function", () => {
-		expectTypeOf<utilities.Parameters<() => void>>().toEqualTypeOf<[]>();
-		expectTypeOf<utilities.Parameters<(foo: string) => void>>().toEqualTypeOf<[string]>();
-		expectTypeOf<utilities.Parameters<(foo: string, bar: number) => void>>().toEqualTypeOf<[string, number]>();
-		expectTypeOf<utilities.Parameters<(foo: { bar: number }) => void>>().toEqualTypeOf<[{ bar: number }]>();
-	});
+    test("Returns the parameters of a function", () => {
+        expectTypeOf<utilities.Parameters<() => void>>().toEqualTypeOf<[]>();
+        expectTypeOf<utilities.Parameters<(foo: string) => void>>().toEqualTypeOf<[string]>();
+        expectTypeOf<utilities.Parameters<(foo: string, bar: number) => void>>().toEqualTypeOf<[string, number]>();
+        expectTypeOf<utilities.Parameters<(foo: { bar: number }) => void>>().toEqualTypeOf<[{ bar: number }]>();
+    });
 });
 
 describe("Includes", () => {
-	test("Check if an element exist withins a tuple", () => {
-		expectTypeOf<utilities.Includes<[], any>>().toEqualTypeOf<false>();
-		expectTypeOf<utilities.Includes<[1, 2, "foo", "bar"], 2>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.Includes<["foo", "bar", () => void, {}], () => void>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.Includes<[string, 1, () => void, {}], string>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.Includes<[string, number, () => void, {}], number>>().toEqualTypeOf<true>();
-		expectTypeOf<utilities.Includes<[true, false, true], number>>().toEqualTypeOf<false>();
-	});
+    test("Check if an element exist withins a tuple", () => {
+        expectTypeOf<utilities.Includes<[], any>>().toEqualTypeOf<false>();
+        expectTypeOf<utilities.Includes<[1, 2, "foo", "bar"], 2>>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.Includes<["foo", "bar", () => void, {}], () => void>>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.Includes<[string, 1, () => void, {}], string>>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.Includes<[string, number, () => void, {}], number>>().toEqualTypeOf<true>();
+        expectTypeOf<utilities.Includes<[true, false, true], number>>().toEqualTypeOf<false>();
+    });
 });
 
 describe("ObjectEntries", () => {
-	test("Returns the entries from an object", () => {
-		expectTypeOf<utilities.ObjectEntries<{ foo: string }>>().toEqualTypeOf<["foo", string]>();
-		expectTypeOf<utilities.ObjectEntries<{ foo?: string }>>().toEqualTypeOf<["foo", string]>();
-		expectTypeOf<utilities.ObjectEntries<{ foo?: string; bar?: number }>>().toEqualTypeOf<
-			["foo", string] | ["bar", number]
-		>();
-		expectTypeOf<utilities.ObjectEntries<{ foo?: undefined; bar: undefined | string }>>().toEqualTypeOf<
-			["foo", undefined] | ["bar", undefined | string]
-		>();
-	});
+    test("Returns the entries from an object", () => {
+        expectTypeOf<utilities.ObjectEntries<{ foo: string }>>().toEqualTypeOf<["foo", string]>();
+        expectTypeOf<utilities.ObjectEntries<{ foo?: string }>>().toEqualTypeOf<["foo", string]>();
+        expectTypeOf<utilities.ObjectEntries<{ foo?: string; bar?: number }>>().toEqualTypeOf<
+            ["foo", string] | ["bar", number]
+        >();
+        expectTypeOf<utilities.ObjectEntries<{ foo?: undefined; bar: undefined | string }>>().toEqualTypeOf<
+            ["foo", undefined] | ["bar", undefined | string]
+        >();
+    });
 });
 
 describe("Pick Utilities", () => {
-	describe("Pick", () => {
-		test("Pick by keys", () => {
-			expectTypeOf<Pick<{ foo: string; bar: number }, never>>().toEqualTypeOf<{}>();
-			expectTypeOf<Pick<{ foo: string; bar: number }, "bar">>().toEqualTypeOf<{ bar: number }>();
-			expectTypeOf<Pick<{ foo: string; bar: number }, "bar" | "foo">>().toEqualTypeOf<{ foo: string; bar: number }>();
-		});
-	});
+    describe("Pick", () => {
+        test("Pick by keys", () => {
+            expectTypeOf<Pick<{ foo: string; bar: number }, never>>().toEqualTypeOf<{}>();
+            expectTypeOf<Pick<{ foo: string; bar: number }, "bar">>().toEqualTypeOf<{ bar: number }>();
+            expectTypeOf<Pick<{ foo: string; bar: number }, "bar" | "foo">>().toEqualTypeOf<{ foo: string; bar: number }>();
+        });
+    });
 
-	describe("PickByType", () => {
-		test("Pick by type", () => {
-			expectTypeOf<utilities.PickByType<{ foo: string; bar: number; foofoo: string }, number>>().toEqualTypeOf<{
-				bar: number;
-			}>();
-			expectTypeOf<utilities.PickByType<{ foo: string; bar: number; foofoo: string }, string>>().toEqualTypeOf<{
-				foo: string;
-				foofoo: string;
-			}>();
-			expectTypeOf<utilities.PickByType<{ foo: () => {}; bar: number }, string>>().toEqualTypeOf<{}>();
-			expectTypeOf<utilities.PickByType<{ foo: () => {}; bar: number; foobar: {} }, never>>().toEqualTypeOf<{}>();
-			expectTypeOf<utilities.PickByType<{ foo: () => {}; bar: number; foobar: {} }, () => {}>>().toEqualTypeOf<{
-				foo: () => {};
-			}>();
-		});
-	});
+    describe("PickByType", () => {
+        test("Pick by type", () => {
+            expectTypeOf<utilities.PickByType<{ foo: string; bar: number; foofoo: string }, number>>().toEqualTypeOf<{
+                bar: number;
+            }>();
+            expectTypeOf<utilities.PickByType<{ foo: string; bar: number; foofoo: string }, string>>().toEqualTypeOf<{
+                foo: string;
+                foofoo: string;
+            }>();
+            expectTypeOf<utilities.PickByType<{ foo: () => {}; bar: number }, string>>().toEqualTypeOf<{}>();
+            expectTypeOf<utilities.PickByType<{ foo: () => {}; bar: number; foobar: {} }, never>>().toEqualTypeOf<{}>();
+            expectTypeOf<utilities.PickByType<{ foo: () => {}; bar: number; foobar: {} }, () => {}>>().toEqualTypeOf<{
+                foo: () => {};
+            }>();
+        });
+    });
 });
 
 describe("ReplaceKeys", () => {
-	test("Replace the key types", () => {
-		expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "bar", { bar: string }>>().toEqualTypeOf<{
-			foo: string;
-			bar: string;
-		}>();
-		expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "foobar", { bar: string }>>().toEqualTypeOf<{
-			foo: string;
-			bar: number;
-		}>();
-		expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "bar", { foobar: string }>>().toEqualTypeOf<{
-			foo: string;
-			bar: unknown;
-		}>();
-		expectTypeOf<
-			utilities.ReplaceKeys<{ foo: string; bar: number }, "foo" | "bar", { foo: number; bar: boolean }>
-		>().toEqualTypeOf<{
-			foo: number;
-			bar: boolean;
-		}>();
-	});
+    test("Replace the key types", () => {
+        expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "bar", { bar: string }>>().toEqualTypeOf<{
+            foo: string;
+            bar: string;
+        }>();
+        expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "foobar", { bar: string }>>().toEqualTypeOf<{
+            foo: string;
+            bar: number;
+        }>();
+        expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "bar", { foobar: string }>>().toEqualTypeOf<{
+            foo: string;
+            bar: unknown;
+        }>();
+        expectTypeOf<
+            utilities.ReplaceKeys<{ foo: string; bar: number }, "foo" | "bar", { foo: number; bar: boolean }>
+        >().toEqualTypeOf<{
+            foo: number;
+            bar: boolean;
+        }>();
+    });
 });
 
 describe("MapTypes", () => {
-	test("Replace the types of the keys that match with Mapper type", () => {
-		expectTypeOf<utilities.MapTypes<{ foo: string; bar: number }, { from: string; to: number }>>().toEqualTypeOf<{
-			foo: number;
-			bar: number;
-		}>();
-		expectTypeOf<utilities.MapTypes<{ foo: number; bar: number }, { from: number; to: string }>>().toEqualTypeOf<{
-			foo: string;
-			bar: string;
-		}>();
-		expectTypeOf<utilities.MapTypes<{ foo: string; bar: number }, { from: boolean; to: number }>>().toEqualTypeOf<{
-			foo: string;
-			bar: number;
-		}>();
-		expectTypeOf<utilities.MapTypes<{ foo: () => {}; bar: string }, { from: () => {}; to: never }>>().toEqualTypeOf<{
-			foo: never;
-			bar: string;
-		}>();
-		expectTypeOf<
-			utilities.MapTypes<{ foo: string; bar: number }, { from: string; to: boolean } | { from: number; to: bigint }>
-		>().toEqualTypeOf<{ foo: boolean; bar: bigint }>();
-	});
+    test("Replace the types of the keys that match with Mapper type", () => {
+        expectTypeOf<utilities.MapTypes<{ foo: string; bar: number }, { from: string; to: number }>>().toEqualTypeOf<{
+            foo: number;
+            bar: number;
+        }>();
+        expectTypeOf<utilities.MapTypes<{ foo: number; bar: number }, { from: number; to: string }>>().toEqualTypeOf<{
+            foo: string;
+            bar: string;
+        }>();
+        expectTypeOf<utilities.MapTypes<{ foo: string; bar: number }, { from: boolean; to: number }>>().toEqualTypeOf<{
+            foo: string;
+            bar: number;
+        }>();
+        expectTypeOf<utilities.MapTypes<{ foo: () => {}; bar: string }, { from: () => {}; to: never }>>().toEqualTypeOf<{
+            foo: never;
+            bar: string;
+        }>();
+        expectTypeOf<
+            utilities.MapTypes<{ foo: string; bar: number }, { from: string; to: boolean } | { from: number; to: bigint }>
+        >().toEqualTypeOf<{ foo: boolean; bar: bigint }>();
+    });
 });
 
 describe("DeepOmit", () => {
-	test("Omit properties from nested objects", () => {
-		expectTypeOf<utilities.DeepOmit<{ foo: string; bar: { foobar: number } }, "foo">>().toEqualTypeOf<{
-			bar: { foobar: number };
-		}>();
-		expectTypeOf<utilities.DeepOmit<{ foo: string; bar: { foobar: number } }, "bar.foobar">>().toEqualTypeOf<{
-			foo: string;
-			bar: {};
-		}>();
-		expectTypeOf<utilities.DeepOmit<{ foo: string; bar: { foobar: number } }, "foobar">>().toEqualTypeOf<{
-			foo: string;
-			bar: { foobar: number };
-		}>();
-		expectTypeOf<
-			utilities.DeepOmit<{ foo: string; bar: { foobar: number; nested: { baz: string } } }, "bar.nested.baz">
-		>().toEqualTypeOf<{
-			foo: string;
-			bar: { foobar: number; nested: {} };
-		}>();
-	});
+    test("Omit properties from nested objects", () => {
+        expectTypeOf<utilities.DeepOmit<{ foo: string; bar: { foobar: number } }, "foo">>().toEqualTypeOf<{
+            bar: { foobar: number };
+        }>();
+        expectTypeOf<utilities.DeepOmit<{ foo: string; bar: { foobar: number } }, "bar.foobar">>().toEqualTypeOf<{
+            foo: string;
+            bar: {};
+        }>();
+        expectTypeOf<utilities.DeepOmit<{ foo: string; bar: { foobar: number } }, "foobar">>().toEqualTypeOf<{
+            foo: string;
+            bar: { foobar: number };
+        }>();
+        expectTypeOf<
+            utilities.DeepOmit<{ foo: string; bar: { foobar: number; nested: { baz: string } } }, "bar.nested.baz">
+        >().toEqualTypeOf<{
+            foo: string;
+            bar: { foobar: number; nested: {} };
+        }>();
+    });
 });
 
 describe("ToPrimitive", () => {
-	test("Converts a string to a primitive type", () => {
-		expectTypeOf<utilities.ToPrimitive<{ foo: string; bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
-		expectTypeOf<utilities.ToPrimitive<{ foo: "foobar"; bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
-		expectTypeOf<utilities.ToPrimitive<{ foo: "foobar"; bar: 12 }>>().toEqualTypeOf<{ foo: string; bar: number }>();
-		expectTypeOf<utilities.ToPrimitive<{ foo: { foobar: "fo"; bar: false }; bar: 12 }>>().toEqualTypeOf<{
-			foo: { foobar: string; bar: boolean };
-			bar: number;
-		}>();
-	});
+    test("Converts a string to a primitive type", () => {
+        expectTypeOf<utilities.ToPrimitive<{ foo: string; bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
+        expectTypeOf<utilities.ToPrimitive<{ foo: "foobar"; bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
+        expectTypeOf<utilities.ToPrimitive<{ foo: "foobar"; bar: 12 }>>().toEqualTypeOf<{ foo: string; bar: number }>();
+        expectTypeOf<utilities.ToPrimitive<{ foo: { foobar: "fo"; bar: false }; bar: 12 }>>().toEqualTypeOf<{
+            foo: { foobar: string; bar: boolean };
+            bar: number;
+        }>();
+    });
 });

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -2,42 +2,42 @@ import { describe, test, expectTypeOf } from "vitest";
 import type * as utilities from "../src/utils";
 
 describe("PercentageParser", () => {
-	test("Parses a percentage string into a tuple", () => {
-		expectTypeOf<utilities.PercentageParser<"foobar">>().toEqualTypeOf<never>();
-		expectTypeOf<utilities.PercentageParser<"2024">>().toEqualTypeOf<["", "2024", ""]>();
-		expectTypeOf<utilities.PercentageParser<"-89">>().toEqualTypeOf<["-", "89", ""]>();
-		expectTypeOf<utilities.PercentageParser<"+89%">>().toEqualTypeOf<["+", "89", "%"]>();
-	});
+    test("Parses a percentage string into a tuple", () => {
+        expectTypeOf<utilities.PercentageParser<"foobar">>().toEqualTypeOf<never>();
+        expectTypeOf<utilities.PercentageParser<"2024">>().toEqualTypeOf<["", "2024", ""]>();
+        expectTypeOf<utilities.PercentageParser<"-89">>().toEqualTypeOf<["-", "89", ""]>();
+        expectTypeOf<utilities.PercentageParser<"+89%">>().toEqualTypeOf<["+", "89", "%"]>();
+    });
 });
 
 describe("Absolute", () => {
-	test("Returns the absolute version of a number", () => {
-		expectTypeOf<utilities.Absolute<-100>>().toEqualTypeOf<"100">();
-		expectTypeOf<utilities.Absolute<-0>>().toEqualTypeOf<"0">();
-		expectTypeOf<utilities.Absolute<-999_999_999_999>>().toEqualTypeOf<"999999999999">();
-		expectTypeOf<utilities.Absolute<-999_999_999_999_999n>>().toEqualTypeOf<"999999999999999">();
-	});
+    test("Returns the absolute version of a number", () => {
+        expectTypeOf<utilities.Absolute<-100>>().toEqualTypeOf<"100">();
+        expectTypeOf<utilities.Absolute<-0>>().toEqualTypeOf<"0">();
+        expectTypeOf<utilities.Absolute<-999_999_999_999>>().toEqualTypeOf<"999999999999">();
+        expectTypeOf<utilities.Absolute<-999_999_999_999_999n>>().toEqualTypeOf<"999999999999999">();
+    });
 });
 
 describe("Trunc", () => {
-	test("Truncate a number to its integer part", () => {
-		expectTypeOf<utilities.Trunc<3.14159>>().toEqualTypeOf<"3">();
-		expectTypeOf<utilities.Trunc<-3.14159>>().toEqualTypeOf<"-3">();
-		expectTypeOf<utilities.Trunc<42.1>>().toEqualTypeOf<"42">();
-		expectTypeOf<utilities.Trunc<0>>().toEqualTypeOf<"0">();
-		expectTypeOf<utilities.Trunc<1289n>>().toEqualTypeOf<"1289">();
-		expectTypeOf<utilities.Trunc<-0.98>>().toEqualTypeOf<"0">();
-		expectTypeOf<utilities.Trunc<-90000.98>>().toEqualTypeOf<"-90000">();
-	});
+    test("Truncate a number to its integer part", () => {
+        expectTypeOf<utilities.Trunc<3.14159>>().toEqualTypeOf<"3">();
+        expectTypeOf<utilities.Trunc<-3.14159>>().toEqualTypeOf<"-3">();
+        expectTypeOf<utilities.Trunc<42.1>>().toEqualTypeOf<"42">();
+        expectTypeOf<utilities.Trunc<0>>().toEqualTypeOf<"0">();
+        expectTypeOf<utilities.Trunc<1289n>>().toEqualTypeOf<"1289">();
+        expectTypeOf<utilities.Trunc<-0.98>>().toEqualTypeOf<"0">();
+        expectTypeOf<utilities.Trunc<-90000.98>>().toEqualTypeOf<"-90000">();
+    });
 });
 
 describe("NumberRange", () => {
-	test("Create a union type with a range of numbers", () => {
-		expectTypeOf<utilities.NumberRange<1, 5>>().toEqualTypeOf<1 | 2 | 3 | 4 | 5>();
-		expectTypeOf<utilities.NumberRange<9, 14>>().toEqualTypeOf<9 | 10 | 11 | 12 | 13 | 14>();
-		expectTypeOf<utilities.NumberRange<-5, 5>>().toEqualTypeOf<never>();
-		expectTypeOf<utilities.NumberRange<0, 0>>().toEqualTypeOf<0>();
-		expectTypeOf<utilities.NumberRange<-5, -5>>().toEqualTypeOf<never>();
-		expectTypeOf<utilities.NumberRange<-5, 0>>().toEqualTypeOf<never>();
-	});
+    test("Create a union type with a range of numbers", () => {
+        expectTypeOf<utilities.NumberRange<1, 5>>().toEqualTypeOf<1 | 2 | 3 | 4 | 5>();
+        expectTypeOf<utilities.NumberRange<9, 14>>().toEqualTypeOf<9 | 10 | 11 | 12 | 13 | 14>();
+        expectTypeOf<utilities.NumberRange<-5, 5>>().toEqualTypeOf<never>();
+        expectTypeOf<utilities.NumberRange<0, 0>>().toEqualTypeOf<0>();
+        expectTypeOf<utilities.NumberRange<-5, -5>>().toEqualTypeOf<never>();
+        expectTypeOf<utilities.NumberRange<-5, 0>>().toEqualTypeOf<never>();
+    });
 });

--- a/test/validate-types.test.ts
+++ b/test/validate-types.test.ts
@@ -2,109 +2,109 @@ import { describe, test, expect } from "vitest";
 import { isPrimitive, isPrimitiveNullish, isBoolean, isNumber, isString, isObject, isArray } from "./../src/validate-types";
 
 describe("Primitive Validation", () => {
-	describe("isPrimitive", () => {
-		test("should return true for primitive values", ({}) => {
-			expect(isPrimitive(1)).toBeTruthy();
-			expect(isPrimitive("str")).toBeTruthy();
-			expect(isPrimitive(true)).toBeTruthy();
-			expect(isPrimitive(BigInt(12))).toBeTruthy();
-			expect(isPrimitive(Symbol("sym"))).toBeTruthy();
-		});
+    describe("isPrimitive", () => {
+        test("should return true for primitive values", ({}) => {
+            expect(isPrimitive(1)).toBeTruthy();
+            expect(isPrimitive("str")).toBeTruthy();
+            expect(isPrimitive(true)).toBeTruthy();
+            expect(isPrimitive(BigInt(12))).toBeTruthy();
+            expect(isPrimitive(Symbol("sym"))).toBeTruthy();
+        });
 
-		test("should return false for primitive values", () => {
-			expect(isPrimitive(null)).toBeFalsy();
-			expect(isPrimitive(undefined)).toBeFalsy();
-			expect(isPrimitive({})).toBeFalsy();
-			expect(isPrimitive(() => {})).toBeFalsy();
-		});
-	});
+        test("should return false for primitive values", () => {
+            expect(isPrimitive(null)).toBeFalsy();
+            expect(isPrimitive(undefined)).toBeFalsy();
+            expect(isPrimitive({})).toBeFalsy();
+            expect(isPrimitive(() => {})).toBeFalsy();
+        });
+    });
 
-	describe("isPrimitiveNullish", () => {
-		test("should return true for primitive values including null and undefined", () => {
-			expect(isPrimitiveNullish(1)).toBeTruthy();
-			expect(isPrimitiveNullish("str")).toBeTruthy();
-			expect(isPrimitiveNullish(true)).toBeTruthy();
-			expect(isPrimitiveNullish(BigInt(12))).toBeTruthy();
-			expect(isPrimitiveNullish(Symbol("symbol"))).toBeTruthy();
-			expect(isPrimitiveNullish(null)).toBeTruthy();
-			expect(isPrimitiveNullish(undefined)).toBeTruthy();
-		});
-		test("should return false for non-primitive values", () => {
-			expect(isPrimitive({})).toBeFalsy();
-			expect(isPrimitive(() => {})).toBeFalsy();
-		});
-	});
+    describe("isPrimitiveNullish", () => {
+        test("should return true for primitive values including null and undefined", () => {
+            expect(isPrimitiveNullish(1)).toBeTruthy();
+            expect(isPrimitiveNullish("str")).toBeTruthy();
+            expect(isPrimitiveNullish(true)).toBeTruthy();
+            expect(isPrimitiveNullish(BigInt(12))).toBeTruthy();
+            expect(isPrimitiveNullish(Symbol("symbol"))).toBeTruthy();
+            expect(isPrimitiveNullish(null)).toBeTruthy();
+            expect(isPrimitiveNullish(undefined)).toBeTruthy();
+        });
+        test("should return false for non-primitive values", () => {
+            expect(isPrimitive({})).toBeFalsy();
+            expect(isPrimitive(() => {})).toBeFalsy();
+        });
+    });
 });
 
 describe("Types validation", () => {
-	describe("isNumber", () => {
-		test("should return true for numbers", () => {
-			expect(isNumber(1)).toBeTruthy();
-		});
+    describe("isNumber", () => {
+        test("should return true for numbers", () => {
+            expect(isNumber(1)).toBeTruthy();
+        });
 
-		test("should return false for non-numbers", () => {
-			expect(isNumber(false)).toBeFalsy();
-			expect(isNumber("str")).toBeFalsy();
-			expect(isNumber(null)).toBeFalsy();
-			expect(isNumber(undefined)).toBeFalsy();
-			expect(isNumber({})).toBeFalsy();
-		});
-	});
+        test("should return false for non-numbers", () => {
+            expect(isNumber(false)).toBeFalsy();
+            expect(isNumber("str")).toBeFalsy();
+            expect(isNumber(null)).toBeFalsy();
+            expect(isNumber(undefined)).toBeFalsy();
+            expect(isNumber({})).toBeFalsy();
+        });
+    });
 
-	describe("isBoolean", () => {
-		test("should return true for booleans", () => {
-			expect(isBoolean(false)).toBeTruthy();
-		});
+    describe("isBoolean", () => {
+        test("should return true for booleans", () => {
+            expect(isBoolean(false)).toBeTruthy();
+        });
 
-		test("should return false for non-booleans", () => {
-			expect(isBoolean(1)).toBeFalsy();
-			expect(isBoolean("str")).toBeFalsy();
-			expect(isBoolean(null)).toBeFalsy();
-			expect(isBoolean(undefined)).toBeFalsy();
-			expect(isBoolean({})).toBeFalsy();
-		});
-	});
+        test("should return false for non-booleans", () => {
+            expect(isBoolean(1)).toBeFalsy();
+            expect(isBoolean("str")).toBeFalsy();
+            expect(isBoolean(null)).toBeFalsy();
+            expect(isBoolean(undefined)).toBeFalsy();
+            expect(isBoolean({})).toBeFalsy();
+        });
+    });
 
-	describe("isString", () => {
-		test("should return true for strings", () => {
-			expect(isString("str")).toBeTruthy();
-		});
+    describe("isString", () => {
+        test("should return true for strings", () => {
+            expect(isString("str")).toBeTruthy();
+        });
 
-		test("should return false for non-strings", () => {
-			expect(isString(1)).toBeFalsy();
-			expect(isString(false)).toBeFalsy();
-			expect(isString(null)).toBeFalsy();
-			expect(isString(undefined)).toBeFalsy();
-			expect(isString({})).toBeFalsy();
-		});
-	});
+        test("should return false for non-strings", () => {
+            expect(isString(1)).toBeFalsy();
+            expect(isString(false)).toBeFalsy();
+            expect(isString(null)).toBeFalsy();
+            expect(isString(undefined)).toBeFalsy();
+            expect(isString({})).toBeFalsy();
+        });
+    });
 
-	describe("isObject", () => {
-		test("should return true for objects", () => {
-			expect(isObject({})).toBeTruthy();
-		});
+    describe("isObject", () => {
+        test("should return true for objects", () => {
+            expect(isObject({})).toBeTruthy();
+        });
 
-		test("should return false for non-objects", () => {
-			expect(isObject(1)).toBeFalsy();
-			expect(isObject(false)).toBeFalsy();
-			expect(isObject("str")).toBeFalsy();
-			expect(isObject(null)).toBeFalsy();
-			expect(isObject(undefined)).toBeFalsy();
-		});
-	});
+        test("should return false for non-objects", () => {
+            expect(isObject(1)).toBeFalsy();
+            expect(isObject(false)).toBeFalsy();
+            expect(isObject("str")).toBeFalsy();
+            expect(isObject(null)).toBeFalsy();
+            expect(isObject(undefined)).toBeFalsy();
+        });
+    });
 
-	describe("isArray", () => {
-		test("should return true for arrays", () => {
-			expect(isArray([])).toBeTruthy();
-			expect(isArray([1, 2, 3])).toBeTruthy();
-		});
+    describe("isArray", () => {
+        test("should return true for arrays", () => {
+            expect(isArray([])).toBeTruthy();
+            expect(isArray([1, 2, 3])).toBeTruthy();
+        });
 
-		test("should return false for non-arrays", () => {
-			expect(isArray(1)).toBeFalsy();
-			expect(isArray(false)).toBeFalsy();
-			expect(isArray("str")).toBeFalsy();
-			expect(isArray(null)).toBeFalsy();
-			expect(isArray(undefined)).toBeFalsy();
-		});
-	});
+        test("should return false for non-arrays", () => {
+            expect(isArray(1)).toBeFalsy();
+            expect(isArray(false)).toBeFalsy();
+            expect(isArray("str")).toBeFalsy();
+            expect(isArray(null)).toBeFalsy();
+            expect(isArray(undefined)).toBeFalsy();
+        });
+    });
 });

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -7,22 +7,22 @@ import { defineConfig } from "tsup";
  * .cjs formats.
  */
 export const tsup = defineConfig([
-	{
-		entry: ["src", "!src/validate-types.ts"],
-		format: ["esm"],
-		outDir: "dist",
-		dts: {
-			only: true,
-		},
-		minify: true,
-		clean: true,
-	},
-	{
-		entry: ["src/validate-types.ts"],
-		format: ["esm", "cjs"],
-		outDir: "dist/utils",
-		dts: true,
-		minify: true,
-		clean: true,
-	},
+    {
+        entry: ["src", "!src/validate-types.ts"],
+        format: ["esm"],
+        outDir: "dist",
+        dts: {
+            only: true,
+        },
+        minify: true,
+        clean: true,
+    },
+    {
+        entry: ["src/validate-types.ts"],
+        format: ["esm", "cjs"],
+        outDir: "dist/utils",
+        dts: true,
+        minify: true,
+        clean: true,
+    },
 ]);

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,13 +1,13 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
-	test: {
-		coverage: {
-			provider: "v8",
-			include: ["test/**/*.test.ts"],
-			exclude: ["node_modules", "dist"],
-			reporter: ["text", "html"],
-			reportsDirectory: "test/coverage",
-		},
-	},
+    test: {
+        coverage: {
+            provider: "v8",
+            include: ["test/**/*.test.ts"],
+            exclude: ["node_modules", "dist"],
+            reporter: ["text", "html"],
+            reportsDirectory: "test/coverage",
+        },
+    },
 });


### PR DESCRIPTION
## Description
This pull request updates the `Prettier` configuration to clean up unnecessary properties and disables the `useTabs` option. Additionally, the format script has been run to apply the new configuration across the codebase.

## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->