### PR TITLE
chore(ci): add `build` step to `ci.yaml` workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -50,6 +50,7 @@ jobs:
           node-version: "18.x"
           registry-url: https://registry.npmjs.org/
       - run: npm install
+      - run: npm run build
       - run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}


### PR DESCRIPTION
## Description
This pull request adds a `build` step to the `ci.yaml` workflow to ensure the full package content is included during publication. Previously, an issue caused only `README.md` and `package.json` files to be published, while the `dist` directory and other necessary files were missing.

## Checklist
- [ ]  Added documentation.
- [ ]  The changes do not generate any warnings.
- [ ]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->