### PR TITLE
chore: update `semi` field in `prettier` config and run `format`

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,19 +18,19 @@ npm i -D @halvaradop/ts-utility-types
 Once installed, you can import the types from your typescript files
 
 ```ts
-import { Merge } from "@halvaradop/ts-utility-types";
+import { Merge } from "@halvaradop/ts-utility-types"
 
 interface Config {
-  storePaths: string[];
-  hooks: unknown[];
+  storePaths: string[]
+  hooks: unknown[]
 }
 
 interface AppStore {
-  path: string;
-  hooks: ArgsFunction[];
+  path: string
+  hooks: ArgsFunction[]
 }
 // Expect: { storePaths: string[], path: string, hooks: ArgsFunction[] }
-export type Store = Merge<Config, AppStore>;
+export type Store = Merge<Config, AppStore>
 ```
 
 ## TypeHero Challenges

--- a/package.json
+++ b/package.json
@@ -60,9 +60,10 @@
     "README.md"
   ],
   "prettier": {
-    "semi": true,
+    "semi": false,
     "tabWidth": 4,
     "printWidth": 130,
+    "trailingComma": "es5",
     "overrides": [
       {
         "files": [

--- a/src/array-types.ts
+++ b/src/array-types.ts
@@ -1,5 +1,5 @@
-import type { ToUnion } from "./object-types.js";
-import type { Equals } from "./test.js";
+import type { ToUnion } from "./object-types.js"
+import type { Equals } from "./test.js"
 
 /**
  * Creates a union type from the literal values of a constant string or number array.
@@ -11,7 +11,7 @@ import type { Equals } from "./test.js";
  */
 export type TupleToUnion<Array extends readonly unknown[]> = Array extends [infer Item, ...infer Spread]
     ? Item | TupleToUnion<Spread>
-    : never;
+    : never
 
 /**
  * Gets the length (size) of an array.
@@ -21,7 +21,7 @@ export type TupleToUnion<Array extends readonly unknown[]> = Array extends [infe
  * // Expected: 5
  * type SizeOfNumbers = Size<typeof numbers>;
  */
-export type Size<Array extends unknown[]> = Array extends unknown[] ? Array["length"] : 0;
+export type Size<Array extends unknown[]> = Array extends unknown[] ? Array["length"] : 0
 
 /**
  * Gets the type of the last element in an array, or `never` if the array is empty.
@@ -30,7 +30,7 @@ export type Size<Array extends unknown[]> = Array extends unknown[] ? Array["len
  * // Expected: 4
  * type LastItem = Last<1, 2, 3, 4>;
  */
-export type Last<Array extends unknown[]> = Array extends [...any, infer Last] ? Last : never;
+export type Last<Array extends unknown[]> = Array extends [...any, infer Last] ? Last : never
 
 /**
  * Removes the last element from an array and returns a new array type with all elements
@@ -43,14 +43,14 @@ export type Last<Array extends unknown[]> = Array extends [...any, infer Last] ?
  * // Expected: [1, 2]
  * type PopNums = Pop<[1, 2, 3]>;
  */
-export type Pop<Array extends unknown[]> = Array extends [...infer Spread, unknown] ? Spread : [];
+export type Pop<Array extends unknown[]> = Array extends [...infer Spread, unknown] ? Spread : []
 
 type FilterImplementation<Array extends unknown[], Predicate, Build extends unknown[] = []> = Array extends [
     infer Item,
     ...infer Spread,
 ]
     ? FilterImplementation<Spread, Predicate, Item extends Predicate ? [...Build, Item] : [...Build]>
-    : Build;
+    : Build
 
 /**
  * Filter the items of a tuple of elements based in the predicate provided in the
@@ -63,14 +63,14 @@ type FilterImplementation<Array extends unknown[], Predicate, Build extends unkn
  * // Expected: [0, 1]
  * type Filter2 = Filter<[0, 1, 2], 0 | 1>
  */
-export type Filter<Array extends unknown[], Predicate> = FilterImplementation<Array, Predicate, []>;
+export type Filter<Array extends unknown[], Predicate> = FilterImplementation<Array, Predicate, []>
 
 type FilterOutImplementation<Array extends readonly unknown[], Predicate, Build extends unknown[] = []> = Array extends [
     infer Item,
     ...infer Spread,
 ]
     ? FilterOutImplementation<Spread, Predicate, Item extends ToUnion<Predicate> ? Build : [...Build, Item]>
-    : Build;
+    : Build
 
 /**
  * Cleans the elements of a tuple based in the predicated, it returns the values that
@@ -83,7 +83,7 @@ type FilterOutImplementation<Array extends readonly unknown[], Predicate, Build 
  * // Expected: ["bar", "foobar"]
  * type CleanStrings = FilterOut<["foo", "bar", "foobar"], "foo">;
  */
-export type FilterOut<Array extends readonly unknown[], Predicate> = FilterOutImplementation<Array, Predicate, []>;
+export type FilterOut<Array extends readonly unknown[], Predicate> = FilterOutImplementation<Array, Predicate, []>
 
 /**
  * Change the relative ordern of the elements of a tuple type, reversing
@@ -99,7 +99,7 @@ export type FilterOut<Array extends readonly unknown[], Predicate> = FilterOutIm
  * // Expected: [() => void, { foo: number }, "bar", 2, "foo", 1]
  * type ReverseArray = Reverse<[1, "foo", 2, "bar", { foo: number }, () => void]>;
  */
-export type Reverse<Array extends unknown[]> = Array extends [infer Item, ...infer Spread] ? [...Reverse<Spread>, Item] : Array;
+export type Reverse<Array extends unknown[]> = Array extends [infer Item, ...infer Spread] ? [...Reverse<Spread>, Item] : Array
 
 type IndexOfImplementation<Array extends unknown[], Match, Index extends unknown[] = []> = Array extends [
     infer Item,
@@ -108,7 +108,7 @@ type IndexOfImplementation<Array extends unknown[], Match, Index extends unknown
     ? Equals<Item, Match> extends true
         ? Index["length"]
         : IndexOfImplementation<Spread, Match, [...Index, Item]>
-    : -1;
+    : -1
 
 /**
  * Returns the first index where the element `Match` appears in the tuple type `Array`.
@@ -127,7 +127,7 @@ type IndexOfImplementation<Array extends unknown[], Match, Index extends unknown
  * // Expected: 1
  * type IndexOf4 = IndexOf<[string, "a"], "a">;
  */
-export type IndexOf<Array extends unknown[], Match> = IndexOfImplementation<Array, Match, []>;
+export type IndexOf<Array extends unknown[], Match> = IndexOfImplementation<Array, Match, []>
 
 type LastIndexOfImplementation<
     Array extends unknown[],
@@ -143,7 +143,7 @@ type LastIndexOfImplementation<
       >
     : IndexOf extends [...any, infer LastIndex]
       ? LastIndex
-      : -1;
+      : -1
 
 /**
  * Returns the last index where the element `Match` appears in the tuple type `Array`.
@@ -162,7 +162,7 @@ type LastIndexOfImplementation<
  * // Expected: 5
  * type LastIndexOf4 = LastIndexOf<[string, any, 1, number, "a", any, 1], any>;
  */
-export type LastIndexOf<Array extends unknown[], Match> = LastIndexOfImplementation<Array, Match, [], []>;
+export type LastIndexOf<Array extends unknown[], Match> = LastIndexOfImplementation<Array, Match, [], []>
 
 /**
  * Helper type to create a tuple with a specific length, repeating a given value
@@ -172,7 +172,7 @@ type RepeatConstructTuple<
     Length extends number,
     Value extends unknown = unknown,
     Array extends unknown[] = [],
-> = Array["length"] extends Length ? Array : RepeatConstructTuple<Length, Value, [...Array, Value]>;
+> = Array["length"] extends Length ? Array : RepeatConstructTuple<Length, Value, [...Array, Value]>
 
 /**
  * reate a tuple with a defined size, where each element is of a specified type
@@ -188,7 +188,7 @@ export type ConstructTuple<
     Length extends number,
     Value extends unknown = unknown,
     Array extends unknown[] = [],
-> = RepeatConstructTuple<Length, Value, Array>;
+> = RepeatConstructTuple<Length, Value, Array>
 
 type CheckRepeatedTupleImplementation<Array extends unknown[], Build extends unknown = never> = Array extends [
     infer Item,
@@ -197,7 +197,7 @@ type CheckRepeatedTupleImplementation<Array extends unknown[], Build extends unk
     ? Item extends Build
         ? true
         : CheckRepeatedTupleImplementation<Spread, Build | Item>
-    : false;
+    : false
 
 /**
  * Check if there are duplidated elements inside the tuple
@@ -209,7 +209,7 @@ type CheckRepeatedTupleImplementation<Array extends unknown[], Build extends unk
  * // Expected: true
  * type TupleNumber2 = CheckRepeatedTuple<[1, 2, 1]>;
  */
-export type CheckRepeatedTuple<Tuple extends unknown[]> = CheckRepeatedTupleImplementation<Tuple>;
+export type CheckRepeatedTuple<Tuple extends unknown[]> = CheckRepeatedTupleImplementation<Tuple>
 
 /**
  * Returns true if all elements within the tuple are equal to `Comparator` otherwise, returns false
@@ -225,7 +225,7 @@ export type AllEquals<Array extends unknown[], Comparator> = Array extends [infe
     ? Equals<Item, Comparator> extends true
         ? AllEquals<Spread, Comparator>
         : false
-    : true;
+    : true
 
 type ChunkImplementation<
     Array extends unknown[],
@@ -238,15 +238,15 @@ type ChunkImplementation<
         : ChunkImplementation<Spread, Size, Build, [...Partition, Item]>
     : Partition["length"] extends 0
       ? Build
-      : [...Build, Partition];
+      : [...Build, Partition]
 
-export type Chunk<Array extends unknown[], Size extends number> = ChunkImplementation<Array, Size, [], []>;
+export type Chunk<Array extends unknown[], Size extends number> = ChunkImplementation<Array, Size, [], []>
 
 type ZipImplementation<T, U, Build extends unknown[] = []> = T extends [infer ItemT, ...infer SpreadT]
     ? U extends [infer ItemU, ...infer SpreadU]
         ? ZipImplementation<SpreadT, SpreadU, [...Build, [ItemT, ItemU]]>
         : Build
-    : Build;
+    : Build
 
 /**
  * Join the elements of two arrays in a tuple of arrays
@@ -258,7 +258,7 @@ type ZipImplementation<T, U, Build extends unknown[] = []> = T extends [infer It
  * // Expected: [[1, "a"], [2, "b"]]
  * type Zip2 = Zip<[1, 2, 3], ["a", "b"]>;
  */
-export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = ZipImplementation<Array1, Array2>;
+export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = ZipImplementation<Array1, Array2>
 
 /**
  * Returns the flatten type of an array.
@@ -270,4 +270,4 @@ export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = ZipImpleme
  * // Expected: string
  * type Flatten2 = FlattenArrayType<string[][][]>;
  */
-export type FlattenArrayType<Array> = Array extends (infer Type)[] ? FlattenArrayType<Type> : Array;
+export type FlattenArrayType<Array> = Array extends (infer Type)[] ? FlattenArrayType<Type> : Array

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-export type * from "./utility-types.js";
-export type * from "./types.js";
-export type * from "./test.js";
-export type * from "./type-guards.js";
-export type * from "./string-mappers.js";
+export type * from "./utility-types.js"
+export type * from "./types.js"
+export type * from "./test.js"
+export type * from "./type-guards.js"
+export type * from "./string-mappers.js"

--- a/src/object-types.ts
+++ b/src/object-types.ts
@@ -1,5 +1,5 @@
-import type { Equals } from "./test.js";
-import type { ArgsFunction, ReturnTypeOf } from "./types.js";
+import type { Equals } from "./test.js"
+import type { ArgsFunction, ReturnTypeOf } from "./types.js"
 
 /**
  * Utility type that transforms an object to have each property on a new line
@@ -8,8 +8,8 @@ import type { ArgsFunction, ReturnTypeOf } from "./types.js";
  * It doesn't change the original object type.
  */
 export type Prettify<Obj extends object> = {
-    [Property in keyof Obj]: Obj[Property];
-} & {};
+    [Property in keyof Obj]: Obj[Property]
+} & {}
 
 /**
  * It creates a new type based on your object but marks every property as readonly
@@ -31,13 +31,13 @@ export type DeepReadonly<Obj extends object> = {
         ? Obj[Property]
         : Obj[Property] extends object
           ? DeepReadonly<Obj[Property]>
-          : Obj[Property];
-};
+          : Obj[Property]
+}
 
 /**
  * Exclude properties of type `Match` from type `T`
  */
-export type Exclude<T, Match> = T extends Match ? never : T;
+export type Exclude<T, Match> = T extends Match ? never : T
 
 /**
  * Get the type of the resolved value of a PromiseLike object.
@@ -47,7 +47,7 @@ export type Awaited<T extends PromiseLike<unknown>> =
         ? ResolveType extends PromiseLike<unknown>
             ? Awaited<ResolveType>
             : ResolveType
-        : never;
+        : never
 
 /**
  * Get the type of the function's arguments
@@ -60,7 +60,7 @@ export type Awaited<T extends PromiseLike<unknown>> =
  * // Expected: [number, number]
  * type AddParams = Parameters<typeof add>;
  */
-export type Parameters<Function extends ArgsFunction> = Function extends (...args: infer Params) => void ? Params : never;
+export type Parameters<Function extends ArgsFunction> = Function extends (...args: infer Params) => void ? Params : never
 
 /**
  * Create a new type with a subset of properties from an object
@@ -76,8 +76,8 @@ export type Parameters<Function extends ArgsFunction> = Function extends (...arg
  * type PickUser = Pick<User, "age">;
  */
 export type Pick<Obj extends object, Keys extends keyof Obj> = {
-    [Property in Keys]: Obj[Property];
-};
+    [Property in Keys]: Obj[Property]
+}
 
 /**
  * Check if a value exists within a tuple and is equal to a specific value
@@ -96,7 +96,7 @@ export type Includes<Array extends unknown[], Match> = Array extends [infer Comp
     ? Equals<Compare, Match> extends true
         ? true
         : Includes<Spread, Match>
-    : false;
+    : false
 
 /**
  * Creates a new type that omits properties from an object type based on another type
@@ -106,8 +106,8 @@ export type Includes<Array extends unknown[], Match> = Array extends [infer Comp
  * type NoEmailPerson = Omit<{ name: string; age: number; email: string }, "email">;
  */
 export type Omit<Obj extends object, Keys extends keyof Obj> = {
-    [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
-};
+    [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property]
+}
 
 /**
  * Creates a union of the keys of two objects
@@ -124,7 +124,7 @@ export type Omit<Obj extends object, Keys extends keyof Obj> = {
  * // Expected: "foo" | "bar"
  * type PropsFooBar = Properties<Foo, Bar>;
  */
-export type Properties<Obj1 extends object, Obj2 extends object> = keyof Obj1 | keyof Obj2;
+export type Properties<Obj1 extends object, Obj2 extends object> = keyof Obj1 | keyof Obj2
 
 /**
  * Creates a new object by merging two objects. Properties from `Obj1` override properties
@@ -145,8 +145,8 @@ export type Properties<Obj1 extends object, Obj2 extends object> = keyof Obj1 | 
  * type MergeConfig = Merge<Config, AppStore>;
  */
 export type Merge<Obj1 extends object, Obj2 extends object> = {
-    [Property in Properties<Obj1, Obj2>]: RetrieveKeyValue<Obj2, Obj1, Property>;
-};
+    [Property in Properties<Obj1, Obj2>]: RetrieveKeyValue<Obj2, Obj1, Property>
+}
 
 /**
  * Create a new object based in the difference keys between the objects.
@@ -171,8 +171,8 @@ export type Intersection<Obj1 extends object, Obj2 extends object> = {
         Obj1,
         Obj2,
         Property
-    >;
-};
+    >
+}
 
 /**
  * Create a new object based in the type of its keys
@@ -188,8 +188,8 @@ export type Intersection<Obj1 extends object, Obj2 extends object> = {
  * type UserStr = PickByType<User, string>;
  */
 export type PickByType<Obj extends object, Type> = {
-    [Property in keyof Obj as Obj[Property] extends Type ? Property : never]: Obj[Property];
-};
+    [Property in keyof Obj as Obj[Property] extends Type ? Property : never]: Obj[Property]
+}
 
 /**
  * Converts the specified keys of an object into optional ones
@@ -206,9 +206,9 @@ export type PickByType<Obj extends object, Type> = {
  */
 export type PartialByKeys<Obj extends object, Keys extends keyof Obj = keyof Obj> = Prettify<
     {
-        [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
+        [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property]
     } & { [Property in Keys]?: Obj[Property] }
->;
+>
 
 /**
  * Create a new object based in the keys that are not assignable of type `Type`
@@ -224,8 +224,8 @@ export type PartialByKeys<Obj extends object, Keys extends keyof Obj = keyof Obj
  * type UserExcludeStrings = OmitByType<User, string>;
  */
 export type OmitByType<Obj extends object, Type> = {
-    [Property in keyof Obj as Obj[Property] extends Type ? never : Property]: Obj[Property];
-};
+    [Property in keyof Obj as Obj[Property] extends Type ? never : Property]: Obj[Property]
+}
 
 /**
  * Extracts the value of a key from an object and returns a new object with that value,
@@ -233,16 +233,16 @@ export type OmitByType<Obj extends object, Type> = {
  */
 export type FlattenProperties<Obj extends object, Keys extends keyof Obj> = Prettify<
     {
-        [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
+        [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property]
     } & Obj[Keys]
->;
+>
 
 /**
  * Removes the properties whose keys start with an underscore (_).
  */
 export type PublicOnly<Obj extends object> = {
-    [Property in keyof Obj as Property extends `_${string}` ? never : Property]: Obj[Property];
-};
+    [Property in keyof Obj as Property extends `_${string}` ? never : Property]: Obj[Property]
+}
 
 /**
  * Checks if a key exists in either of the two objects and returns its value.
@@ -252,7 +252,7 @@ export type RetrieveKeyValue<Obj1 extends object, Obj2 extends object, Key> = Ke
     ? Obj1[Key]
     : Key extends keyof Obj2
       ? Obj2[Key]
-      : never;
+      : never
 
 /**
  * Convert to required the keys speficied in the type `Keys`, and the others fields mantein
@@ -270,11 +270,11 @@ export type RetrieveKeyValue<Obj1 extends object, Obj2 extends object, Key> = Ke
  */
 export type RequiredByKeys<Obj extends object, Keys extends keyof Obj = keyof Obj> = Prettify<
     {
-        [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property];
+        [Property in keyof Obj as Property extends Keys ? never : Property]: Obj[Property]
     } & {
-        [Property in keyof Obj as Property extends Keys ? Property : never]-?: Obj[Property];
+        [Property in keyof Obj as Property extends Keys ? Property : never]-?: Obj[Property]
     }
->;
+>
 
 /**
  *
@@ -299,8 +299,8 @@ export type UnionMerge<Obj1 extends object, Obj2 extends object> = {
             : Obj1[Prop]
         : Prop extends keyof Obj2
           ? Obj2[Prop]
-          : never;
-};
+          : never
+}
 
 /**
  * Converts top-level readonly properties of an object to mutable properties.
@@ -318,8 +318,8 @@ export type UnionMerge<Obj1 extends object, Obj2 extends object> = {
  * type NonReadonlyUser = Mutable<User>;
  */
 export type Mutable<Obj extends object> = {
-    -readonly [Property in keyof Obj]: Obj[Property];
-};
+    -readonly [Property in keyof Obj]: Obj[Property]
+}
 
 /**
  * Converts all properties to non-readonly of alls levels of the object type,
@@ -338,15 +338,15 @@ export type Mutable<Obj extends object> = {
  * type NonReadonlyFoo = DeepMutable<Foo>;
  */
 export type DeepMutable<Obj extends object> = {
-    -readonly [Property in keyof Obj]: Obj[Property] extends object ? DeepMutable<Obj[Property]> : Obj[Property];
-};
+    -readonly [Property in keyof Obj]: Obj[Property] extends object ? DeepMutable<Obj[Property]> : Obj[Property]
+}
 
 type MergeAllImplementation<Array extends readonly object[], Merge extends object = {}> = Array extends [
     infer Item,
     ...infer Spread,
 ]
     ? MergeAllImplementation<Spread extends object[] ? Spread : never, UnionMerge<Merge, Item extends object ? Item : {}>>
-    : Merge;
+    : Merge
 
 /**
  * Create a new object type based in the tuple of object types, if the properties
@@ -370,7 +370,7 @@ type MergeAllImplementation<Array extends readonly object[], Merge extends objec
  * // Expected: { foo: string | boolean, bar: string | number, foobar: string }
  * type Merge = MergeAll<[Foo, Bar, FooBar]>;
  */
-export type MergeAll<Array extends readonly object[]> = MergeAllImplementation<Array, {}>;
+export type MergeAll<Array extends readonly object[]> = MergeAllImplementation<Array, {}>
 
 /**
  * Create an union type based in the literal values of the tuple provided.
@@ -387,7 +387,7 @@ export type MergeAll<Array extends readonly object[]> = MergeAllImplementation<A
  * // Expected: 1 | ["foo" | "bar"]
  * type TupleMultiple = ToUnion<1 | ["foo" | "bar"]>;
  */
-export type ToUnion<T> = T extends [infer Item, ...infer Spread] ? Item | ToUnion<Spread> : T;
+export type ToUnion<T> = T extends [infer Item, ...infer Spread] ? Item | ToUnion<Spread> : T
 
 /**
  * Create a new object type appending a new property with its value
@@ -401,8 +401,8 @@ export type ToUnion<T> = T extends [infer Item, ...infer Spread] ? Item | ToUnio
  * type UserAppendLastname = AddPropertyToObject<User, "lastname", string>;
  */
 export type AddPropertyToObject<Obj extends object, NewProp extends string, TypeValue> = {
-    [Property in keyof Obj | NewProp]: Property extends keyof Obj ? Obj[Property] : TypeValue;
-};
+    [Property in keyof Obj | NewProp]: Property extends keyof Obj ? Obj[Property] : TypeValue
+}
 
 /**
  * Returns a union type of the entries of the provided object
@@ -418,8 +418,8 @@ export type AddPropertyToObject<Obj extends object, NewProp extends string, Type
  * type FooEntries = ObjectEntries<Foo>;
  */
 export type ObjectEntries<Obj extends object, RequiredObj extends object = Required<Obj>> = {
-    [Property in keyof RequiredObj]: [Property, RequiredObj[Property] extends undefined ? undefined : RequiredObj[Property]];
-}[keyof RequiredObj];
+    [Property in keyof RequiredObj]: [Property, RequiredObj[Property] extends undefined ? undefined : RequiredObj[Property]]
+}[keyof RequiredObj]
 
 /**
  * Replaces the types of the keys in an object with new types defined in the `Replace` object.
@@ -440,8 +440,8 @@ export type ReplaceKeys<Obj extends object, Keys extends string, Replace extends
         ? Property extends keyof Replace
             ? Replace[Property]
             : Default
-        : Obj[Property];
-};
+        : Obj[Property]
+}
 
 /**
  * Transforms the types of the keys in an object that match the `from` type in the `Mapper`,
@@ -461,8 +461,8 @@ export type MapTypes<Obj extends object, Mapper extends { from: unknown; to: unk
                 ? To
                 : never
             : Obj[Property]
-        : Obj[Property];
-};
+        : Obj[Property]
+}
 
 /**
  * Omits properties of an object at any depth based on the provided pattern.
@@ -493,8 +493,8 @@ export type DeepOmit<Obj extends object, Pattern extends string> = {
                 ? DeepOmit<Obj[Property], Spread>
                 : Obj[Property]
             : Obj[Property]
-        : Obj[Property];
-};
+        : Obj[Property]
+}
 
 /**
  * Transforms the object properties to their primitive types. If the properties are objects,
@@ -515,5 +515,5 @@ export type ToPrimitive<Obj extends object> = {
         ? Obj[Property] extends Function
             ? Function
             : ToPrimitive<Obj[Property]>
-        : ReturnTypeOf<Obj[Property]>;
-};
+        : ReturnTypeOf<Obj[Property]>
+}

--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -1,5 +1,5 @@
-import type { Equals } from "./test.js";
-import type { LetterToLowercase, LetterToUppercase, WhiteSpaces } from "./types.js";
+import type { Equals } from "./test.js"
+import type { LetterToLowercase, LetterToUppercase, WhiteSpaces } from "./types.js"
 
 /**
  * Removes leading whitespace characters from a string type
@@ -7,7 +7,7 @@ import type { LetterToLowercase, LetterToUppercase, WhiteSpaces } from "./types.
  * // Expected: "hello world  "
  * type TrimmedLeft = TrimLeft<"  hello world  ">;
  */
-export type TrimLeft<Str extends string> = Str extends `${WhiteSpaces}${infer Characters}` ? TrimLeft<Characters> : Str;
+export type TrimLeft<Str extends string> = Str extends `${WhiteSpaces}${infer Characters}` ? TrimLeft<Characters> : Str
 
 /**
  * Removes trailing whitespace characters from a string type
@@ -15,7 +15,7 @@ export type TrimLeft<Str extends string> = Str extends `${WhiteSpaces}${infer Ch
  * // Expected: "hello world"
  * type TrimmedRight = TrimRight<"hello world  ">;
  */
-export type TrimRight<Str extends string> = Str extends `${infer Char}${WhiteSpaces}` ? TrimRight<Char> : Str;
+export type TrimRight<Str extends string> = Str extends `${infer Char}${WhiteSpaces}` ? TrimRight<Char> : Str
 
 /**
  * Removes leading and trailing whitespace characters from a string type
@@ -27,7 +27,7 @@ export type Trim<Str extends string> = Str extends `${WhiteSpaces}${infer Charac
     ? Trim<Characters>
     : Str extends `${infer Char}${WhiteSpaces}`
       ? Trim<Char>
-      : Str;
+      : Str
 
 /**
  *  Converts a string to uppercase
@@ -36,7 +36,7 @@ export type Uppercase<Str extends string> = Str extends `${infer Char}${infer Ch
     ? Char extends keyof LetterToUppercase
         ? `${LetterToUppercase[Char]}${Uppercase<Characters>}`
         : `${Char}${Uppercase<Characters>}`
-    : Str;
+    : Str
 
 /**
  * Converts a string to lowercase
@@ -45,7 +45,7 @@ export type Lowercase<Str extends string> = Str extends `${infer Char}${infer Ch
     ? Char extends keyof LetterToLowercase
         ? `${LetterToLowercase[Char]}${Lowercase<Characters>}`
         : `${Char}${Lowercase<Characters>}`
-    : Str;
+    : Str
 
 /**
  * Capitalizes the first letter of a word and converts the rest to lowercase
@@ -58,14 +58,14 @@ export type Capitalize<Str extends string, FirstWord extends boolean = true> = S
               ? ` ${Capitalize<Characters, true>}`
               : `${Lowercase<Char>}${Capitalize<Characters, false>}`
         : Str
-    : Str;
+    : Str
 
 type JoinImplementation<Array extends unknown[], Separator extends number | string, Str extends string = ""> = Array extends [
     infer Char,
     ...infer Chars,
 ]
     ? JoinImplementation<Chars, Separator, `${Str}${Str extends "" ? "" : Separator}${Char & string}`>
-    : Str;
+    : Str
 
 /**
  * Create a string type based on the values of a tuple type `T`, joining the values
@@ -78,7 +78,7 @@ type JoinImplementation<Array extends unknown[], Separator extends number | stri
  * // Expected: "Hello World"
  * type Join2 = Join<["Hello", "World"], " ">
  */
-export type Join<Array extends unknown[], Separator extends number | string> = JoinImplementation<Array, Separator>;
+export type Join<Array extends unknown[], Separator extends number | string> = JoinImplementation<Array, Separator>
 
 /**
  * Checks if a string type matchs start with a strig `U`
@@ -93,7 +93,7 @@ export type Join<Array extends unknown[], Separator extends number | string> = J
  * // Expected: false
  * type Test3 = StartsWith<"abc", "abcd">
  */
-export type StartsWith<Str extends string, Match extends string> = Str extends `${Match}${string}` ? true : false;
+export type StartsWith<Str extends string, Match extends string> = Str extends `${Match}${string}` ? true : false
 
 type DropCharImplementation<
     Str extends string,
@@ -101,7 +101,7 @@ type DropCharImplementation<
     Build extends string = "",
 > = Str extends `${infer Char}${infer Chars}`
     ? DropCharImplementation<Chars, Match, Char extends Match ? Build : `${Build}${Char}`>
-    : Build;
+    : Build
 
 /**
  * Returns a new string type by removing all occurrences of the character `Match` from the string `Str`
@@ -113,7 +113,7 @@ type DropCharImplementation<
  * // Expected: "butterfly!"
  * type Test2 = DropChar<" b u t t e r f l y ! ", " ">
  */
-export type DropChar<Str extends string, Match extends string> = DropCharImplementation<Str, Match>;
+export type DropChar<Str extends string, Match extends string> = DropCharImplementation<Str, Match>
 
 /**
  * Checks if a string type matchs start with a strig `Match`
@@ -125,11 +125,11 @@ export type DropChar<Str extends string, Match extends string> = DropCharImpleme
  * // Expected: false
  * type Test2 = EndsWith<"abc", "ac">
  */
-export type EndsWith<Str extends string, Match extends string> = Str extends `${string}${Match}` ? true : false;
+export type EndsWith<Str extends string, Match extends string> = Str extends `${string}${Match}` ? true : false
 
 type LengthOfStringImplementation<Str extends string, Length extends unknown[] = []> = Str extends `${infer Char}${infer Chars}`
     ? LengthOfStringImplementation<Chars, [...Length, Char]>
-    : Length["length"];
+    : Length["length"]
 
 /**
  * Returns the length of a string type
@@ -141,7 +141,7 @@ type LengthOfStringImplementation<Str extends string, Length extends unknown[] =
  * // Expected: 6
  * type Length6 = LengthOfString<"foobar">
  */
-export type LengthOfString<Str extends string> = LengthOfStringImplementation<Str>;
+export type LengthOfString<Str extends string> = LengthOfStringImplementation<Str>
 
 type IndexOfStringImplementation<
     Str extends string,
@@ -151,7 +151,7 @@ type IndexOfStringImplementation<
     ? Equals<Char, Match> extends true
         ? Index["length"]
         : IndexOfStringImplementation<Chars, Match, [...Index, 1]>
-    : -1;
+    : -1
 
 /**
  * Returns the first index of the character that matches `Match`.
@@ -164,7 +164,7 @@ type IndexOfStringImplementation<
  * // Expected: -1
  * type IndexOfOutBound = IndexOfString<"comparator is a function", "z">
  */
-export type IndexOfString<Str extends string, Match extends string> = IndexOfStringImplementation<Str, Match>;
+export type IndexOfString<Str extends string, Match extends string> = IndexOfStringImplementation<Str, Match>
 
 type FirstUniqueCharIndexImplementation<
     Str extends string,
@@ -176,7 +176,7 @@ type FirstUniqueCharIndexImplementation<
             ? FirstUniqueCharIndexImplementation<Chars, [...Index, 1], Char | Build>
             : Index["length"]
         : FirstUniqueCharIndexImplementation<Chars, [...Index, 1], Char | Build>
-    : -1;
+    : -1
 
 /**
  * Returns the first index of a character that is unique within the given string.
@@ -189,7 +189,7 @@ type FirstUniqueCharIndexImplementation<
  * // Expected: -1
  * type IndexOfOutBound = FirstUniqueCharIndex<"aabbcc">
  */
-export type FirstUniqueCharIndex<Str extends string> = FirstUniqueCharIndexImplementation<Str>;
+export type FirstUniqueCharIndex<Str extends string> = FirstUniqueCharIndexImplementation<Str>
 
 /**
  * Replaces the first match of the substring `From` in the string `S` with the new value `To`
@@ -205,7 +205,7 @@ export type Replace<S extends string, From extends string, To extends string> = 
     ? S
     : S extends `${infer Head}${From}${infer Tail}`
       ? `${Head}${To}${Tail}`
-      : S;
+      : S
 
 type CheckRepeatedCharsImplementation<
     Str extends string,
@@ -214,7 +214,7 @@ type CheckRepeatedCharsImplementation<
     ? Char extends Characters
         ? true
         : CheckRepeatedCharsImplementation<Chars, Characters | Char>
-    : false;
+    : false
 
 /**
  * Check if there are repeated characters in a string type
@@ -226,7 +226,7 @@ type CheckRepeatedCharsImplementation<
  * // Expected: true
  * type Check1 = CheckRepeatedChars<"hello world">
  */
-export type CheckRepeatedChars<Str extends string> = CheckRepeatedCharsImplementation<Str>;
+export type CheckRepeatedChars<Str extends string> = CheckRepeatedCharsImplementation<Str>
 
 type ParseUrlParamsImplementation<
     URLParams extends string,
@@ -237,7 +237,7 @@ type ParseUrlParamsImplementation<
         : ParseUrlParamsImplementation<Route, Params>
     : URLParams extends `:${infer WithoutDots}`
       ? Params | WithoutDots
-      : Params;
+      : Params
 
 /**
  * eturns a union type of the dynamic route parameters in a URL pattern
@@ -249,7 +249,7 @@ type ParseUrlParamsImplementation<
  * // Expected: "id" | "postId"
  * type Test2 = ParseUrlParams<"users/:id/posts/:postId">
  */
-export type ParseUrlParams<URLParams extends string> = ParseUrlParamsImplementation<URLParams>;
+export type ParseUrlParams<URLParams extends string> = ParseUrlParamsImplementation<URLParams>
 
 type FindAllImplementation<
     Str extends string,
@@ -262,7 +262,7 @@ type FindAllImplementation<
       ? Str extends `${Match}${string}`
           ? FindAllImplementation<Characters, Match, [...Index, 1], [...Indexes, Index["length"]]>
           : FindAllImplementation<Characters, Match, [...Index, 1], Indexes>
-      : Indexes;
+      : Indexes
 
 /**
  * Returns indexes the substring that matches `Match` in the string `Str`
@@ -274,4 +274,4 @@ type FindAllImplementation<
  * // Expected: [2, 3, 9]
  * type Test2 = FindAll<"hello world", "l">
  */
-export type FindAll<Str extends string, Match extends string> = FindAllImplementation<Str, Match>;
+export type FindAll<Str extends string, Match extends string> = FindAllImplementation<Str, Match>

--- a/src/test.ts
+++ b/src/test.ts
@@ -8,7 +8,7 @@
  * // Expected: false
  * type CheckTrue = Equals<() => {}, true>;
  */
-export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false;
+export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false
 
 /**
  * Ensures that the parameter is true.
@@ -20,4 +20,4 @@ export type Equals<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T ext
  * // Expected: false
  * type CheckFalse = Expect<false>;
  */
-export type Expect<T extends true> = T;
+export type Expect<T extends true> = T

--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -1,4 +1,4 @@
-import type { Even, Odd } from "./types.js";
+import type { Even, Odd } from "./types.js"
 
 /**
  * Check if the parameter is a never value
@@ -10,7 +10,7 @@ import type { Even, Odd } from "./types.js";
  * // Expected: false
  * type CheckStr = IsNever<string>;
  */
-export type IsNever<T> = [T] extends [never] ? true : false;
+export type IsNever<T> = [T] extends [never] ? true : false
 
 /**
  * Check if the number provided is odd or not
@@ -22,7 +22,7 @@ export type IsNever<T> = [T] extends [never] ? true : false;
  * // Expected: false
  * type CheckEven = IsOdd<2024>;
  */
-export type IsOdd<T extends number> = `${T}` extends `${string}${Odd}` ? true : false;
+export type IsOdd<T extends number> = `${T}` extends `${string}${Odd}` ? true : false
 
 /**
  * Check if the number provided is even or not
@@ -34,4 +34,4 @@ export type IsOdd<T extends number> = `${T}` extends `${string}${Odd}` ? true : 
  * // Expected: false
  * type CheckOdd = IsEven<2023>;
  */
-export type IsEven<T extends number> = `${T}` extends `${string}${Even}` ? false : true;
+export type IsEven<T extends number> = `${T}` extends `${string}${Even}` ? false : true

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,20 +9,20 @@
  *   callback((x: number, y: number, z: number) => {})
  * }
  */
-export type ArgsFunction = (...args: any) => void;
+export type ArgsFunction = (...args: any) => void
 
 /**
  * Represents the absence of a value, typically `null` or `undefined`.
  * This type is useful for checking for optional values or indicating
  * a lack of data.
  */
-export type Nullish = null | undefined;
+export type Nullish = null | undefined
 
 /**
  * Represents a primitive data type that can also be null or undefined.
  * This type is useful for situations where nullish values are allowed.
  */
-export type PrimitiveNullish = number | string | boolean | bigint | symbol | Nullish;
+export type PrimitiveNullish = number | string | boolean | bigint | symbol | Nullish
 
 /**
  * Represents a primitive data type: number, string, boolean, bigint, or symbol.
@@ -30,92 +30,92 @@ export type PrimitiveNullish = number | string | boolean | bigint | symbol | Nul
  *
  * @remarks This type excludes nullish values (null and undefined).
  */
-export type Primitive = Omit<PrimitiveNullish, "null" | "undefined">;
+export type Primitive = Omit<PrimitiveNullish, "null" | "undefined">
 
 /**
  * Represents a whitespace character: space, newline, tab, carriage return, form feed,
  * line separator, or paragraph separator.
  */
-export type WhiteSpaces = " " | "\n" | "\t" | "\r" | "\f" | "\u2028" | "\u2029";
+export type WhiteSpaces = " " | "\n" | "\t" | "\r" | "\f" | "\u2028" | "\u2029"
 
 /**
  * Maps lowercase letters to their uppercase equivalents
  */
 export interface LetterToUppercase {
-    a: "A";
-    b: "B";
-    c: "C";
-    d: "D";
-    e: "E";
-    f: "F";
-    g: "G";
-    h: "H";
-    i: "I";
-    j: "J";
-    k: "K";
-    l: "L";
-    m: "M";
-    n: "N";
-    o: "O";
-    p: "P";
-    q: "Q";
-    r: "R";
-    s: "S";
-    t: "T";
-    u: "U";
-    v: "V";
-    w: "W";
-    x: "X";
-    y: "Y";
-    z: "Z";
+    a: "A"
+    b: "B"
+    c: "C"
+    d: "D"
+    e: "E"
+    f: "F"
+    g: "G"
+    h: "H"
+    i: "I"
+    j: "J"
+    k: "K"
+    l: "L"
+    m: "M"
+    n: "N"
+    o: "O"
+    p: "P"
+    q: "Q"
+    r: "R"
+    s: "S"
+    t: "T"
+    u: "U"
+    v: "V"
+    w: "W"
+    x: "X"
+    y: "Y"
+    z: "Z"
 }
 
 /**
  * Maps uppercase letters to their lowercase equivalents
  */
 export interface LetterToLowercase {
-    A: "a";
-    B: "b";
-    C: "c";
-    D: "d";
-    E: "e";
-    F: "f";
-    G: "g";
-    H: "h";
-    I: "i";
-    J: "j";
-    K: "k";
-    L: "l";
-    M: "m";
-    N: "n";
-    O: "o";
-    P: "p";
-    Q: "q";
-    R: "r";
-    S: "s";
-    T: "t";
-    U: "u";
-    V: "v";
-    W: "w";
-    X: "x";
-    Y: "y";
-    Z: "z";
+    A: "a"
+    B: "b"
+    C: "c"
+    D: "d"
+    E: "e"
+    F: "f"
+    G: "g"
+    H: "h"
+    I: "i"
+    J: "j"
+    K: "k"
+    L: "l"
+    M: "m"
+    N: "n"
+    O: "o"
+    P: "p"
+    Q: "q"
+    R: "r"
+    S: "s"
+    T: "t"
+    U: "u"
+    V: "v"
+    W: "w"
+    X: "x"
+    Y: "y"
+    Z: "z"
 }
 
 /**
  * Represents the empty values
  */
-export type Falsy = Nullish | 0 | false | "";
+export type Falsy = Nullish | 0 | false | ""
 
 /**
  * The odd digits
  */
-export type Odd = 1 | 3 | 5 | 7 | 9;
+export type Odd = 1 | 3 | 5 | 7 | 9
 
 /**
  * The even digits
  */
-export type Even = 0 | 2 | 4 | 6 | 8;
+export type Even = 0 | 2 | 4 | 6 | 8
 
 /**
  * Determines the primitive type corresponding to the provided value.
@@ -137,4 +137,4 @@ export type ReturnTypeOf<T> = T extends string
           ? boolean
           : T extends Function
             ? Function
-            : never;
+            : never

--- a/src/utility-types.ts
+++ b/src/utility-types.ts
@@ -1,3 +1,3 @@
-export type * from "./utils.js";
-export type * from "./array-types.js";
-export type * from "./object-types.js";
+export type * from "./utils.js"
+export type * from "./array-types.js"
+export type * from "./object-types.js"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { DropChar } from "./string-mappers.js";
+import type { DropChar } from "./string-mappers.js"
 
 /**
  * Parses a percentage string into a tuple of [Sign, Number, Unit].
@@ -28,12 +28,12 @@ export type PercentageParser<
             : Char extends "." | ","
               ? PercentageParser<Char, Sign, `${Num}${Char}`, Unit>
               : never
-    : [Sign, Num, Unit];
+    : [Sign, Num, Unit]
 
 /**
  * Returns the absolute version of a number, string or bigint as a string
  */
-export type Absolute<Expression extends number | string | bigint> = DropChar<`${Expression}`, "-" | "n">;
+export type Absolute<Expression extends number | string | bigint> = DropChar<`${Expression}`, "-" | "n">
 
 /**
  * Truncates a number to its integer part.
@@ -51,7 +51,7 @@ export type Trunc<Math extends string | number | bigint> = `${Math}` extends `.$
       ? Chars extends `-0${string}`
           ? "0"
           : Chars
-      : `${Math}`;
+      : `${Math}`
 
 /**
  * Creates a series of numbers between the range of `Low` and `High`. This utility type
@@ -71,7 +71,7 @@ type NumberRangeImplementation<
       ? Range | Index["length"]
       : LowRange extends true
         ? NumberRangeImplementation<Low, High, Range | Index["length"], [...Index, 1], LowRange>
-        : NumberRangeImplementation<Low, High, Range, [...Index, 1], LowRange>;
+        : NumberRangeImplementation<Low, High, Range, [...Index, 1], LowRange>
 
 /**
  * Creates a range of numbers that starts from `Low` and ends in `High`. The range is inclusive
@@ -91,4 +91,4 @@ export type NumberRange<Low extends number, High extends number> = `${Low}` exte
       ? never
       : Low extends High
         ? Low
-        : NumberRangeImplementation<Low, High>;
+        : NumberRangeImplementation<Low, High>

--- a/src/validate-types.ts
+++ b/src/validate-types.ts
@@ -1,9 +1,9 @@
-import type { Nullish, Primitive, PrimitiveNullish } from "./types.js";
+import type { Nullish, Primitive, PrimitiveNullish } from "./types.js"
 
 /**
  * Define the types of primitive values in JavaScript and TypeScript.
  */
-const primitives = ["number", "string", "boolean", "bigint", "symbol"];
+const primitives = ["number", "string", "boolean", "bigint", "symbol"]
 
 /**
  * Checks if a value is a primitive data type (number, string, boolean, bigint, or symbol)
@@ -12,8 +12,8 @@ const primitives = ["number", "string", "boolean", "bigint", "symbol"];
  * @returns {boolean} `true` if the value is a primitive type, `false` otherwise
  */
 export const isPrimitive = (value: unknown): value is Primitive => {
-    return primitives.some((primitive) => typeof value === primitive);
-};
+    return primitives.some((primitive) => typeof value === primitive)
+}
 
 /**
  * Checks if a value is a primitive data type (including null and undefined).
@@ -21,28 +21,28 @@ export const isPrimitive = (value: unknown): value is Primitive => {
  * @param value The value to check
  * @returns {boolean} `true` if the value is a primitive type with nullish values, `false` otherwise
  */
-export const isPrimitiveNullish = (value: unknown): value is PrimitiveNullish => isNullish(value) || isPrimitive(value);
+export const isPrimitiveNullish = (value: unknown): value is PrimitiveNullish => isNullish(value) || isPrimitive(value)
 
 /**
  * Checks if a value is nullish (null or undefined).
  * @param value The value to check
  * @returns `true` if the value is nullish, `false` otherwise
  */
-export const isNullish = (value: unknown): value is Nullish => value === null || value === undefined;
+export const isNullish = (value: unknown): value is Nullish => value === null || value === undefined
 
 /**
  * Checks if a value is a boolean type
  * @param value The value to check
  * @returns {boolean} `true` if the value is a boolean, `false` otherwise
  */
-export const isBoolean = (value: unknown): value is boolean => typeof value === "boolean";
+export const isBoolean = (value: unknown): value is boolean => typeof value === "boolean"
 
 /**
  * Checks if a value is a string type
  * @param value The value to check
  * @returns {boolean} `true` if the value is a string, `false` otherwise
  */
-export const isString = (value: unknown): value is string => typeof value === "string";
+export const isString = (value: unknown): value is string => typeof value === "string"
 
 /**
  *Checks if a value is a number type
@@ -50,25 +50,25 @@ export const isString = (value: unknown): value is string => typeof value === "s
  * @returns {boolean} `true` if the value is a number, `false` otherwise.
  * (Note: `NaN` is also considered a number)
  */
-export const isNumber = (value: unknown): value is number => typeof value === "number";
+export const isNumber = (value: unknown): value is number => typeof value === "number"
 
 /**
  * Checks if a value is a plain object type (not null, array, or function)
  * @param value The value to check
  * @returns {boolean} `true` if the value is a plain object, `false` otherwise
  */
-export const isObject = (value: unknown): value is object => !isNullish(value) && typeof value === "object" && !isArray(value);
+export const isObject = (value: unknown): value is object => !isNullish(value) && typeof value === "object" && !isArray(value)
 
 /**
  * Check if the value is an array value
  * @param value The value to check
  * @returns {boolean} true if the value passed is an rray
  */
-export const isArray = (value: unknown): value is unknown[] => Array.isArray(value);
+export const isArray = (value: unknown): value is unknown[] => Array.isArray(value)
 
 /**
  * Check if the value is a function
  * @param value The value to check
  * @returns {boolean} true if the value passed is a function
  */
-export const isFunction = (value: unknown): value is Function => typeof value === "function";
+export const isFunction = (value: unknown): value is Function => typeof value === "function"

--- a/test/array-types.test.ts
+++ b/test/array-types.test.ts
@@ -1,148 +1,148 @@
-import { describe, test, expectTypeOf } from "vitest";
-import type * as utilities from "../src/array-types";
+import { describe, test, expectTypeOf } from "vitest"
+import type * as utilities from "../src/array-types"
 
 describe("TupleToUnion", () => {
     test("Create union type", () => {
-        expectTypeOf<utilities.TupleToUnion<["foo", "bar"]>>().toEqualTypeOf<"foo" | "bar">();
-        expectTypeOf<utilities.TupleToUnion<[1, 2]>>().toEqualTypeOf<1 | 2>();
-        expectTypeOf<utilities.TupleToUnion<["foo", 1, "bar", 2]>>().toEqualTypeOf<"foo" | "bar" | 1 | 2>();
-    });
-});
+        expectTypeOf<utilities.TupleToUnion<["foo", "bar"]>>().toEqualTypeOf<"foo" | "bar">()
+        expectTypeOf<utilities.TupleToUnion<[1, 2]>>().toEqualTypeOf<1 | 2>()
+        expectTypeOf<utilities.TupleToUnion<["foo", 1, "bar", 2]>>().toEqualTypeOf<"foo" | "bar" | 1 | 2>()
+    })
+})
 
 describe("Tuple methods", () => {
     describe("Last", () => {
         test("Retrieve the last element of a tuple", () => {
-            expectTypeOf<utilities.Last<[]>>().toEqualTypeOf<never>();
-            expectTypeOf<utilities.Last<[1, 2, 3]>>().toEqualTypeOf<3>();
-            expectTypeOf<utilities.Last<["foo", "bar", "foobar"]>>().toEqualTypeOf<"foobar">();
-        });
-    });
+            expectTypeOf<utilities.Last<[]>>().toEqualTypeOf<never>()
+            expectTypeOf<utilities.Last<[1, 2, 3]>>().toEqualTypeOf<3>()
+            expectTypeOf<utilities.Last<["foo", "bar", "foobar"]>>().toEqualTypeOf<"foobar">()
+        })
+    })
 
     describe("Pop", () => {
         test("Remove the last element of a tuple", () => {
-            expectTypeOf<utilities.Pop<[]>>().toEqualTypeOf<[]>();
-            expectTypeOf<utilities.Pop<[1, 2, 3]>>().toEqualTypeOf<[1, 2]>();
-            expectTypeOf<utilities.Pop<["foo", "bar", "foobar"]>>().toEqualTypeOf<["foo", "bar"]>();
-        });
-    });
+            expectTypeOf<utilities.Pop<[]>>().toEqualTypeOf<[]>()
+            expectTypeOf<utilities.Pop<[1, 2, 3]>>().toEqualTypeOf<[1, 2]>()
+            expectTypeOf<utilities.Pop<["foo", "bar", "foobar"]>>().toEqualTypeOf<["foo", "bar"]>()
+        })
+    })
 
     describe("Size", () => {
         test("Returns the size of the tuple", () => {
-            expectTypeOf<utilities.Size<[]>>().toEqualTypeOf<0>();
-            expectTypeOf<utilities.Size<[1, 2, 3]>>().toEqualTypeOf<3>();
-            expectTypeOf<utilities.Size<["foo", "bar", "foobar", 1, 2, never, () => void, { foo: string }]>>().toEqualTypeOf<8>();
-        });
-    });
+            expectTypeOf<utilities.Size<[]>>().toEqualTypeOf<0>()
+            expectTypeOf<utilities.Size<[1, 2, 3]>>().toEqualTypeOf<3>()
+            expectTypeOf<utilities.Size<["foo", "bar", "foobar", 1, 2, never, () => void, { foo: string }]>>().toEqualTypeOf<8>()
+        })
+    })
 
     describe("Filter", () => {
         test("Filter the elements based in the predicate", () => {
-            expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0>>().toEqualTypeOf<[0]>();
-            expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0 | 4>>().toEqualTypeOf<[0, 4]>();
-            expectTypeOf<utilities.Filter<[0, 0, 1, 1, 1], 1>>().toEqualTypeOf<[1, 1, 1]>();
-            expectTypeOf<utilities.Filter<["foo", "bar", "foobar"], "bar">>().toEqualTypeOf<["bar"]>();
-        });
-    });
+            expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0>>().toEqualTypeOf<[0]>()
+            expectTypeOf<utilities.Filter<[0, 1, 2, 3, 4], 0 | 4>>().toEqualTypeOf<[0, 4]>()
+            expectTypeOf<utilities.Filter<[0, 0, 1, 1, 1], 1>>().toEqualTypeOf<[1, 1, 1]>()
+            expectTypeOf<utilities.Filter<["foo", "bar", "foobar"], "bar">>().toEqualTypeOf<["bar"]>()
+        })
+    })
 
     describe("FilterOut", () => {
         test("Removes the elements present in the predicate", () => {
-            expectTypeOf<utilities.FilterOut<[1, 2, 3, 4, 5], [4, 5]>>().toEqualTypeOf<[1, 2, 3]>();
-            expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar"], "foo">>().toEqualTypeOf<["bar", "foobar"]>();
-            expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar", 1, 2], "foo" | 2>>().toEqualTypeOf<["bar", "foobar", 1]>();
+            expectTypeOf<utilities.FilterOut<[1, 2, 3, 4, 5], [4, 5]>>().toEqualTypeOf<[1, 2, 3]>()
+            expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar"], "foo">>().toEqualTypeOf<["bar", "foobar"]>()
+            expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar", 1, 2], "foo" | 2>>().toEqualTypeOf<["bar", "foobar", 1]>()
             expectTypeOf<
                 utilities.FilterOut<[{ foo: string }, { bar: number }, { foobar: boolean }], { bar: number }>
-            >().toEqualTypeOf<[{ foo: string }, { foobar: boolean }]>();
+            >().toEqualTypeOf<[{ foo: string }, { foobar: boolean }]>()
             expectTypeOf<utilities.FilterOut<["foo", "bar", "foobar", 1, 2, { foo: string }], { foo: string }>>().toEqualTypeOf<
                 ["foo", "bar", "foobar", 1, 2]
-            >();
-        });
-    });
+            >()
+        })
+    })
 
     describe("Reverse", () => {
         test("Reverse the elements of a tuple type", () => {
-            expectTypeOf<utilities.Reverse<[1, 2, 3, 4]>>().toEqualTypeOf<[4, 3, 2, 1]>();
-            expectTypeOf<utilities.Reverse<["a", "b", "c"]>>().toEqualTypeOf<["c", "b", "a"]>();
+            expectTypeOf<utilities.Reverse<[1, 2, 3, 4]>>().toEqualTypeOf<[4, 3, 2, 1]>()
+            expectTypeOf<utilities.Reverse<["a", "b", "c"]>>().toEqualTypeOf<["c", "b", "a"]>()
             expectTypeOf<utilities.Reverse<[1, "foo", 2, "bar", { foo: number }, () => void]>>().toEqualTypeOf<
                 [() => void, { foo: number }, "bar", 2, "foo", 1]
-            >();
-        });
-    });
+            >()
+        })
+    })
 
     describe("IndexOf", () => {
         test("Get first index of an element", () => {
-            expectTypeOf<utilities.IndexOf<[0, 0, 0], 2>>().toEqualTypeOf<-1>();
-            expectTypeOf<utilities.IndexOf<[string, 1, number, "a"], number>>().toEqualTypeOf<2>();
-            expectTypeOf<utilities.IndexOf<[string, 1, number, "a", any], any>>().toEqualTypeOf<4>();
-            expectTypeOf<utilities.IndexOf<[string, "a"], "a">>().toEqualTypeOf<1>();
-        });
+            expectTypeOf<utilities.IndexOf<[0, 0, 0], 2>>().toEqualTypeOf<-1>()
+            expectTypeOf<utilities.IndexOf<[string, 1, number, "a"], number>>().toEqualTypeOf<2>()
+            expectTypeOf<utilities.IndexOf<[string, 1, number, "a", any], any>>().toEqualTypeOf<4>()
+            expectTypeOf<utilities.IndexOf<[string, "a"], "a">>().toEqualTypeOf<1>()
+        })
 
         test("Get last index of an element", () => {
-            expectTypeOf<utilities.LastIndexOf<[1, 2, 3, 2, 1], 2>>().toEqualTypeOf<3>();
-            expectTypeOf<utilities.LastIndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3>>().toEqualTypeOf<7>();
-            expectTypeOf<utilities.LastIndexOf<[string, 2, number, "a", number, 1], number>>().toEqualTypeOf<4>();
-            expectTypeOf<utilities.LastIndexOf<[string, any, 1, number, "a", any, 1], any>>().toEqualTypeOf<5>();
-        });
-    });
-});
+            expectTypeOf<utilities.LastIndexOf<[1, 2, 3, 2, 1], 2>>().toEqualTypeOf<3>()
+            expectTypeOf<utilities.LastIndexOf<[2, 6, 3, 8, 4, 1, 7, 3, 9], 3>>().toEqualTypeOf<7>()
+            expectTypeOf<utilities.LastIndexOf<[string, 2, number, "a", number, 1], number>>().toEqualTypeOf<4>()
+            expectTypeOf<utilities.LastIndexOf<[string, any, 1, number, "a", any, 1], any>>().toEqualTypeOf<5>()
+        })
+    })
+})
 
 describe("ConstructTuple", () => {
     test("Create a tuple with a defined size", () => {
-        expectTypeOf<utilities.ConstructTuple<2>>().toEqualTypeOf<[unknown, unknown]>();
-        expectTypeOf<utilities.ConstructTuple<2, string>>().toEqualTypeOf<[string, string]>();
-        expectTypeOf<utilities.ConstructTuple<5, any>>().toEqualTypeOf<[any, any, any, any, any]>();
-    });
-});
+        expectTypeOf<utilities.ConstructTuple<2>>().toEqualTypeOf<[unknown, unknown]>()
+        expectTypeOf<utilities.ConstructTuple<2, string>>().toEqualTypeOf<[string, string]>()
+        expectTypeOf<utilities.ConstructTuple<5, any>>().toEqualTypeOf<[any, any, any, any, any]>()
+    })
+})
 
 describe("CheckRepeatedTuple", () => {
     test("Check if there are duplicated elements", () => {
-        expectTypeOf<utilities.CheckRepeatedTuple<[]>>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.CheckRepeatedTuple<[1, 2, 1]>>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.CheckRepeatedTuple<["foo", "bar", 1, 5]>>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.CheckRepeatedTuple<[() => void, () => void]>>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.CheckRepeatedTuple<[{ foo: string }, { foo: string }]>>().toEqualTypeOf<true>();
-    });
-});
+        expectTypeOf<utilities.CheckRepeatedTuple<[]>>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.CheckRepeatedTuple<[1, 2, 1]>>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.CheckRepeatedTuple<["foo", "bar", 1, 5]>>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.CheckRepeatedTuple<[() => void, () => void]>>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.CheckRepeatedTuple<[{ foo: string }, { foo: string }]>>().toEqualTypeOf<true>()
+    })
+})
 
 describe("AllEquals", () => {
     test("Check if all elements are equal", () => {
-        expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 1>>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 0>>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.AllEquals<[0, 0, 1, 0], 1>>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.AllEquals<[number, number, number, number], number>>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.AllEquals<[[1], [1], [1]], [1]>>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.AllEquals<[{}, {}, {}], {}>>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.AllEquals<[1, 1, 2], 1 | 2>>().toEqualTypeOf<false>();
-    });
-});
+        expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 1>>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.AllEquals<[0, 0, 0, 0], 0>>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.AllEquals<[0, 0, 1, 0], 1>>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.AllEquals<[number, number, number, number], number>>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.AllEquals<[[1], [1], [1]], [1]>>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.AllEquals<[{}, {}, {}], {}>>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.AllEquals<[1, 1, 2], 1 | 2>>().toEqualTypeOf<false>()
+    })
+})
 
 describe("Chunk", () => {
     test("Split an array into chunks", () => {
-        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 1>>().toEqualTypeOf<[[1], [2], [3], [4], [5]]>();
-        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 2>>().toEqualTypeOf<[[1, 2], [3, 4], [5]]>();
-        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 3>>().toEqualTypeOf<[[1, 2, 3], [4, 5]]>();
-        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 4>>().toEqualTypeOf<[[1, 2, 3, 4], [5]]>();
-        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 5>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
-        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 6>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
-        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], -2>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>();
-    });
-});
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 1>>().toEqualTypeOf<[[1], [2], [3], [4], [5]]>()
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 2>>().toEqualTypeOf<[[1, 2], [3, 4], [5]]>()
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 3>>().toEqualTypeOf<[[1, 2, 3], [4, 5]]>()
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 4>>().toEqualTypeOf<[[1, 2, 3, 4], [5]]>()
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 5>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>()
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], 6>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>()
+        expectTypeOf<utilities.Chunk<[1, 2, 3, 4, 5], -2>>().toEqualTypeOf<[[1, 2, 3, 4, 5]]>()
+    })
+})
 
 describe("Zip", () => {
     test("Zip two arrays into a tuple", () => {
-        expectTypeOf<utilities.Zip<[], []>>().toEqualTypeOf<[]>();
-        expectTypeOf<utilities.Zip<[1, 2, 3], ["foo"]>>().toEqualTypeOf<[[1, "foo"]]>();
-        expectTypeOf<utilities.Zip<[1, "bar", 3], ["foo", 2]>>().toEqualTypeOf<[[1, "foo"], ["bar", 2]]>();
+        expectTypeOf<utilities.Zip<[], []>>().toEqualTypeOf<[]>()
+        expectTypeOf<utilities.Zip<[1, 2, 3], ["foo"]>>().toEqualTypeOf<[[1, "foo"]]>()
+        expectTypeOf<utilities.Zip<[1, "bar", 3], ["foo", 2]>>().toEqualTypeOf<[[1, "foo"], ["bar", 2]]>()
         expectTypeOf<utilities.Zip<[{ foo: string }, { bar: string }], ["foo", "bar"]>>().toEqualTypeOf<
             [[{ foo: string }, "foo"], [{ bar: string }, "bar"]]
-        >();
-    });
-});
+        >()
+    })
+})
 
 describe("FlattenArrayType", () => {
     test("Flatten an array type", () => {
-        expectTypeOf<utilities.FlattenArrayType<number[]>>().toEqualTypeOf<number>();
-        expectTypeOf<utilities.FlattenArrayType<number[][]>>().toEqualTypeOf<number>();
-        expectTypeOf<utilities.FlattenArrayType<number[][][]>>().toEqualTypeOf<number>();
-        expectTypeOf<utilities.FlattenArrayType<string[][][][]>>().toEqualTypeOf<string>();
-        expectTypeOf<utilities.FlattenArrayType<unknown[][][][]>>().toEqualTypeOf<unknown>();
-    });
-});
+        expectTypeOf<utilities.FlattenArrayType<number[]>>().toEqualTypeOf<number>()
+        expectTypeOf<utilities.FlattenArrayType<number[][]>>().toEqualTypeOf<number>()
+        expectTypeOf<utilities.FlattenArrayType<number[][][]>>().toEqualTypeOf<number>()
+        expectTypeOf<utilities.FlattenArrayType<string[][][][]>>().toEqualTypeOf<string>()
+        expectTypeOf<utilities.FlattenArrayType<unknown[][][][]>>().toEqualTypeOf<unknown>()
+    })
+})

--- a/test/string-mappers.test.ts
+++ b/test/string-mappers.test.ts
@@ -1,148 +1,148 @@
-import { describe, test, expectTypeOf } from "vitest";
-import type * as utilities from "../src/string-mappers";
+import { describe, test, expectTypeOf } from "vitest"
+import type * as utilities from "../src/string-mappers"
 
 describe("String mappers", () => {
     test("TrimLeft", () => {
-        expectTypeOf<utilities.TrimLeft<"  foo">>().toMatchTypeOf<"foo">();
-        expectTypeOf<utilities.TrimLeft<"   foo bar">>().toMatchTypeOf<"foo bar">();
-        expectTypeOf<utilities.TrimLeft<"\r\r\r\nfoo bar">>().toMatchTypeOf<"foo bar">();
-    });
+        expectTypeOf<utilities.TrimLeft<"  foo">>().toMatchTypeOf<"foo">()
+        expectTypeOf<utilities.TrimLeft<"   foo bar">>().toMatchTypeOf<"foo bar">()
+        expectTypeOf<utilities.TrimLeft<"\r\r\r\nfoo bar">>().toMatchTypeOf<"foo bar">()
+    })
 
     test("TrimRight", () => {
-        expectTypeOf<utilities.TrimRight<"foo  ">>().toMatchTypeOf<"foo">();
-        expectTypeOf<utilities.TrimRight<"foo bar  ">>().toMatchTypeOf<"foo bar">();
-        expectTypeOf<utilities.TrimRight<"foo bar  \n\n">>().toMatchTypeOf<"foo bar">();
-    });
+        expectTypeOf<utilities.TrimRight<"foo  ">>().toMatchTypeOf<"foo">()
+        expectTypeOf<utilities.TrimRight<"foo bar  ">>().toMatchTypeOf<"foo bar">()
+        expectTypeOf<utilities.TrimRight<"foo bar  \n\n">>().toMatchTypeOf<"foo bar">()
+    })
 
     test("Trim", () => {
-        expectTypeOf<utilities.Trim<"  foo">>().toMatchTypeOf<"foo">();
-        expectTypeOf<utilities.Trim<"foo  ">>().toMatchTypeOf<"foo">();
-        expectTypeOf<utilities.Trim<"  foo  ">>().toMatchTypeOf<"foo">();
-        expectTypeOf<utilities.Trim<"\r\n foo \r\n">>().toMatchTypeOf<"foo">();
-    });
+        expectTypeOf<utilities.Trim<"  foo">>().toMatchTypeOf<"foo">()
+        expectTypeOf<utilities.Trim<"foo  ">>().toMatchTypeOf<"foo">()
+        expectTypeOf<utilities.Trim<"  foo  ">>().toMatchTypeOf<"foo">()
+        expectTypeOf<utilities.Trim<"\r\n foo \r\n">>().toMatchTypeOf<"foo">()
+    })
 
     test("Uppercase", () => {
-        expectTypeOf<utilities.Uppercase<"foo">>().toMatchTypeOf<"FOO">();
-        expectTypeOf<utilities.Uppercase<"Foo">>().toMatchTypeOf<"FOO">();
-        expectTypeOf<utilities.Uppercase<"Foo bar">>().toMatchTypeOf<"FOO BAR">();
-        expectTypeOf<utilities.Uppercase<"Foo Bar">>().toMatchTypeOf<"FOO BAR">();
-    });
+        expectTypeOf<utilities.Uppercase<"foo">>().toMatchTypeOf<"FOO">()
+        expectTypeOf<utilities.Uppercase<"Foo">>().toMatchTypeOf<"FOO">()
+        expectTypeOf<utilities.Uppercase<"Foo bar">>().toMatchTypeOf<"FOO BAR">()
+        expectTypeOf<utilities.Uppercase<"Foo Bar">>().toMatchTypeOf<"FOO BAR">()
+    })
 
     test("Lowercase", () => {
-        expectTypeOf<utilities.Lowercase<"foo">>().toMatchTypeOf<"foo">();
-        expectTypeOf<utilities.Lowercase<"Foo">>().toMatchTypeOf<"foo">();
-        expectTypeOf<utilities.Lowercase<"Foo bar">>().toMatchTypeOf<"foo bar">();
-        expectTypeOf<utilities.Lowercase<"Foo Bar">>().toMatchTypeOf<"foo bar">();
-    });
+        expectTypeOf<utilities.Lowercase<"foo">>().toMatchTypeOf<"foo">()
+        expectTypeOf<utilities.Lowercase<"Foo">>().toMatchTypeOf<"foo">()
+        expectTypeOf<utilities.Lowercase<"Foo bar">>().toMatchTypeOf<"foo bar">()
+        expectTypeOf<utilities.Lowercase<"Foo Bar">>().toMatchTypeOf<"foo bar">()
+    })
 
     test("Capitalize the strings", () => {
-        expectTypeOf<utilities.Capitalize<"foo">>().toMatchTypeOf<"Foo">();
-        expectTypeOf<utilities.Capitalize<"foo bar">>().toMatchTypeOf<"Foo Bar">();
-        expectTypeOf<utilities.Capitalize<"Foo">>().toMatchTypeOf<"Foo">();
-        expectTypeOf<utilities.Capitalize<"Foo bar">>().toMatchTypeOf<"Foo Bar">();
-        expectTypeOf<utilities.Capitalize<"Foo Bar">>().toMatchTypeOf<"Foo Bar">();
-    });
-});
+        expectTypeOf<utilities.Capitalize<"foo">>().toMatchTypeOf<"Foo">()
+        expectTypeOf<utilities.Capitalize<"foo bar">>().toMatchTypeOf<"Foo Bar">()
+        expectTypeOf<utilities.Capitalize<"Foo">>().toMatchTypeOf<"Foo">()
+        expectTypeOf<utilities.Capitalize<"Foo bar">>().toMatchTypeOf<"Foo Bar">()
+        expectTypeOf<utilities.Capitalize<"Foo Bar">>().toMatchTypeOf<"Foo Bar">()
+    })
+})
 
 describe("Join", () => {
-    test("Join the elements of a tuple separated by a character", () => {});
-    expectTypeOf<utilities.Join<["a", "p", "p", "l", "e"], "-">>().toEqualTypeOf<"a-p-p-l-e">();
-    expectTypeOf<utilities.Join<["Hello", "World"], " ">>().toEqualTypeOf<"Hello World">();
-    expectTypeOf<utilities.Join<["2", "2", "2"], "1">>().toEqualTypeOf<"21212">();
-});
+    test("Join the elements of a tuple separated by a character", () => {})
+    expectTypeOf<utilities.Join<["a", "p", "p", "l", "e"], "-">>().toEqualTypeOf<"a-p-p-l-e">()
+    expectTypeOf<utilities.Join<["Hello", "World"], " ">>().toEqualTypeOf<"Hello World">()
+    expectTypeOf<utilities.Join<["2", "2", "2"], "1">>().toEqualTypeOf<"21212">()
+})
 
 describe("Match strings", () => {
     test("StartsWith", () => {
-        expectTypeOf<utilities.StartsWith<"foobar", "foo">>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.StartsWith<"foobar", "bar">>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.StartsWith<"foobar", "obar">>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.StartsWith<"foobar", "foobarr">>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.StartsWith<"foobar", "">>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.StartsWith<"", "">>().toEqualTypeOf<true>();
-    });
+        expectTypeOf<utilities.StartsWith<"foobar", "foo">>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.StartsWith<"foobar", "bar">>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.StartsWith<"foobar", "obar">>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.StartsWith<"foobar", "foobarr">>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.StartsWith<"foobar", "">>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.StartsWith<"", "">>().toEqualTypeOf<true>()
+    })
 
     test("EndsWith", () => {
-        expectTypeOf<utilities.EndsWith<"foobar", "foo">>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.EndsWith<"foobar", "bar">>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.EndsWith<"bar", "br">>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.EndsWith<"foobar", " ">>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.EndsWith<"foobar", "">>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.EndsWith<"", "">>().toEqualTypeOf<true>();
-    });
-});
+        expectTypeOf<utilities.EndsWith<"foobar", "foo">>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.EndsWith<"foobar", "bar">>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.EndsWith<"bar", "br">>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.EndsWith<"foobar", " ">>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.EndsWith<"foobar", "">>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.EndsWith<"", "">>().toEqualTypeOf<true>()
+    })
+})
 
 describe("DropChar", () => {
     test("Remove the characters that match with the given char", () => {
-        expectTypeOf<utilities.DropChar<"foobar foo!", " ">>().toEqualTypeOf<"foobarfoo!">();
-        expectTypeOf<utilities.DropChar<"f o o b a r f o o !", " ">>().toEqualTypeOf<"foobarfoo!">();
-        expectTypeOf<utilities.DropChar<"f o o b a r f o o !", any>>().toEqualTypeOf<"">();
-    });
-});
+        expectTypeOf<utilities.DropChar<"foobar foo!", " ">>().toEqualTypeOf<"foobarfoo!">()
+        expectTypeOf<utilities.DropChar<"f o o b a r f o o !", " ">>().toEqualTypeOf<"foobarfoo!">()
+        expectTypeOf<utilities.DropChar<"f o o b a r f o o !", any>>().toEqualTypeOf<"">()
+    })
+})
 
 describe("LengthOfString", () => {
     test("Returns the length of a string type", () => {
-        expectTypeOf<utilities.LengthOfString<"">>().toEqualTypeOf<0>();
-        expectTypeOf<utilities.LengthOfString<any>>().toEqualTypeOf<0>();
-        expectTypeOf<utilities.LengthOfString<never>>().toEqualTypeOf<never>();
-        expectTypeOf<utilities.LengthOfString<"foobarfoobar">>().toEqualTypeOf<12>();
-    });
-});
+        expectTypeOf<utilities.LengthOfString<"">>().toEqualTypeOf<0>()
+        expectTypeOf<utilities.LengthOfString<any>>().toEqualTypeOf<0>()
+        expectTypeOf<utilities.LengthOfString<never>>().toEqualTypeOf<never>()
+        expectTypeOf<utilities.LengthOfString<"foobarfoobar">>().toEqualTypeOf<12>()
+    })
+})
 
 describe("IndexOfString", () => {
     test("Returns the first index occurrence of a character", () => {
-        expectTypeOf<utilities.IndexOfString<"", never>>().toEqualTypeOf<-1>();
-        expectTypeOf<utilities.IndexOfString<"foobar", "f">>().toEqualTypeOf<0>();
-        expectTypeOf<utilities.IndexOfString<"foobar", "b">>().toEqualTypeOf<3>();
-        expectTypeOf<utilities.IndexOfString<"foobar", "r">>().toEqualTypeOf<5>();
-        expectTypeOf<utilities.IndexOfString<"foobar", "x">>().toEqualTypeOf<-1>();
-    });
-});
+        expectTypeOf<utilities.IndexOfString<"", never>>().toEqualTypeOf<-1>()
+        expectTypeOf<utilities.IndexOfString<"foobar", "f">>().toEqualTypeOf<0>()
+        expectTypeOf<utilities.IndexOfString<"foobar", "b">>().toEqualTypeOf<3>()
+        expectTypeOf<utilities.IndexOfString<"foobar", "r">>().toEqualTypeOf<5>()
+        expectTypeOf<utilities.IndexOfString<"foobar", "x">>().toEqualTypeOf<-1>()
+    })
+})
 
 describe("FirstUniqueCharIndex", () => {
     test("Returns the first index of a character that is not repeated", () => {
-        expectTypeOf<utilities.FirstUniqueCharIndex<"">>().toEqualTypeOf<-1>();
-        expectTypeOf<utilities.FirstUniqueCharIndex<"comparator">>().toEqualTypeOf<0>();
-        expectTypeOf<utilities.FirstUniqueCharIndex<"comparator and comparable">>().toEqualTypeOf<7>();
-        expectTypeOf<utilities.FirstUniqueCharIndex<"aabbcc">>().toEqualTypeOf<-1>();
-        expectTypeOf<utilities.FirstUniqueCharIndex<"aabcb">>().toEqualTypeOf<3>();
-    });
-});
+        expectTypeOf<utilities.FirstUniqueCharIndex<"">>().toEqualTypeOf<-1>()
+        expectTypeOf<utilities.FirstUniqueCharIndex<"comparator">>().toEqualTypeOf<0>()
+        expectTypeOf<utilities.FirstUniqueCharIndex<"comparator and comparable">>().toEqualTypeOf<7>()
+        expectTypeOf<utilities.FirstUniqueCharIndex<"aabbcc">>().toEqualTypeOf<-1>()
+        expectTypeOf<utilities.FirstUniqueCharIndex<"aabcb">>().toEqualTypeOf<3>()
+    })
+})
 
 describe("Replace", () => {
     test("Replace the first match with a new value", () => {
-        expectTypeOf<utilities.Replace<"foobar", "bar", "foo">>().toEqualTypeOf<"foofoo">();
-        expectTypeOf<utilities.Replace<"foobarbar", "bar", "foo">>().toEqualTypeOf<"foofoobar">();
-        expectTypeOf<utilities.Replace<"foobarbar", "", "foo">>().toEqualTypeOf<"foobarbar">();
-        expectTypeOf<utilities.Replace<"foobarbar", "bar", "">>().toEqualTypeOf<"foobar">();
-    });
-});
+        expectTypeOf<utilities.Replace<"foobar", "bar", "foo">>().toEqualTypeOf<"foofoo">()
+        expectTypeOf<utilities.Replace<"foobarbar", "bar", "foo">>().toEqualTypeOf<"foofoobar">()
+        expectTypeOf<utilities.Replace<"foobarbar", "", "foo">>().toEqualTypeOf<"foobarbar">()
+        expectTypeOf<utilities.Replace<"foobarbar", "bar", "">>().toEqualTypeOf<"foobar">()
+    })
+})
 
 describe("CheckRepeatedChars", () => {
     test("Check if there are repeated characters in the string", () => {
-        expectTypeOf<utilities.CheckRepeatedChars<"">>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.CheckRepeatedChars<"aba">>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.CheckRepeatedChars<"abcza">>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.CheckRepeatedChars<"añlamnhj">>().toEqualTypeOf<true>();
-    });
-});
+        expectTypeOf<utilities.CheckRepeatedChars<"">>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.CheckRepeatedChars<"aba">>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.CheckRepeatedChars<"abcza">>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.CheckRepeatedChars<"añlamnhj">>().toEqualTypeOf<true>()
+    })
+})
 
 describe("ParseUrlParams", () => {
     test("Parse the URL parameters", () => {
-        expectTypeOf<utilities.ParseUrlParams<"posts/:id">>().toEqualTypeOf<"id">();
-        expectTypeOf<utilities.ParseUrlParams<":posts/:id">>().toEqualTypeOf<"posts" | "id">();
-        expectTypeOf<utilities.ParseUrlParams<"user/:id/posts/:postId">>().toEqualTypeOf<"id" | "postId">();
-        expectTypeOf<utilities.ParseUrlParams<":posts/:id">>().toEqualTypeOf<"posts" | "id">();
-        expectTypeOf<utilities.ParseUrlParams<"posts/:id/:items/likes">>().toEqualTypeOf<"id" | "items">();
-    });
-});
+        expectTypeOf<utilities.ParseUrlParams<"posts/:id">>().toEqualTypeOf<"id">()
+        expectTypeOf<utilities.ParseUrlParams<":posts/:id">>().toEqualTypeOf<"posts" | "id">()
+        expectTypeOf<utilities.ParseUrlParams<"user/:id/posts/:postId">>().toEqualTypeOf<"id" | "postId">()
+        expectTypeOf<utilities.ParseUrlParams<":posts/:id">>().toEqualTypeOf<"posts" | "id">()
+        expectTypeOf<utilities.ParseUrlParams<"posts/:id/:items/likes">>().toEqualTypeOf<"id" | "items">()
+    })
+})
 
 describe("FindAll", () => {
     test("Find all the indexes of a substring in a string", () => {
-        expectTypeOf<utilities.FindAll<"", "">>().toEqualTypeOf<[]>();
-        expectTypeOf<utilities.FindAll<"ooooo", "">>().toEqualTypeOf<[]>();
-        expectTypeOf<utilities.FindAll<"", "foobar">>().toEqualTypeOf<[]>();
-        expectTypeOf<utilities.FindAll<"foobar", "o">>().toEqualTypeOf<[1, 2]>();
-        expectTypeOf<utilities.FindAll<"foooo", "o">>().toEqualTypeOf<[1, 2, 3, 4]>();
-        expectTypeOf<utilities.FindAll<"ooooo", "oo">>().toEqualTypeOf<[0, 1, 2, 3]>();
-    });
-});
+        expectTypeOf<utilities.FindAll<"", "">>().toEqualTypeOf<[]>()
+        expectTypeOf<utilities.FindAll<"ooooo", "">>().toEqualTypeOf<[]>()
+        expectTypeOf<utilities.FindAll<"", "foobar">>().toEqualTypeOf<[]>()
+        expectTypeOf<utilities.FindAll<"foobar", "o">>().toEqualTypeOf<[1, 2]>()
+        expectTypeOf<utilities.FindAll<"foooo", "o">>().toEqualTypeOf<[1, 2, 3, 4]>()
+        expectTypeOf<utilities.FindAll<"ooooo", "oo">>().toEqualTypeOf<[0, 1, 2, 3]>()
+    })
+})

--- a/test/type-guards.test.ts
+++ b/test/type-guards.test.ts
@@ -1,26 +1,26 @@
-import { describe, test, expectTypeOf } from "vitest";
-import type { IsNever, IsOdd } from "../src/type-guards";
+import { describe, test, expectTypeOf } from "vitest"
+import type { IsNever, IsOdd } from "../src/type-guards"
 
 describe("Utility types for type guards", () => {
     describe("IsNever", () => {
         test("should return false for non-never types", () => {
-            expectTypeOf<IsNever<string>>().toEqualTypeOf<false>();
-            expectTypeOf<IsNever<number>>().toEqualTypeOf<false>();
-        });
+            expectTypeOf<IsNever<string>>().toEqualTypeOf<false>()
+            expectTypeOf<IsNever<number>>().toEqualTypeOf<false>()
+        })
 
         test("should return true for never type", () => {
-            expectTypeOf<IsNever<never>>().toEqualTypeOf<true>();
-        });
-    });
+            expectTypeOf<IsNever<never>>().toEqualTypeOf<true>()
+        })
+    })
 
     describe("IsOdd", () => {
         test("Check if a number is odd", () => {
-            expectTypeOf<IsOdd<0>>().toEqualTypeOf<false>();
-            expectTypeOf<IsOdd<2023>>().toEqualTypeOf<true>();
-            expectTypeOf<IsOdd<2024>>().toEqualTypeOf<false>();
-            expectTypeOf<IsOdd<number>>().toEqualTypeOf<false>();
-            expectTypeOf<IsOdd<1234567891>>().toEqualTypeOf<true>();
-            expectTypeOf<IsOdd<1234567892>>().toEqualTypeOf<false>();
-        });
-    });
-});
+            expectTypeOf<IsOdd<0>>().toEqualTypeOf<false>()
+            expectTypeOf<IsOdd<2023>>().toEqualTypeOf<true>()
+            expectTypeOf<IsOdd<2024>>().toEqualTypeOf<false>()
+            expectTypeOf<IsOdd<number>>().toEqualTypeOf<false>()
+            expectTypeOf<IsOdd<1234567891>>().toEqualTypeOf<true>()
+            expectTypeOf<IsOdd<1234567892>>().toEqualTypeOf<false>()
+        })
+    })
+})

--- a/test/utility-type.test.ts
+++ b/test/utility-type.test.ts
@@ -1,115 +1,115 @@
-import { describe, test, expectTypeOf } from "vitest";
+import { describe, test, expectTypeOf } from "vitest"
 //import type * as utilities from "../src/utility-types";
-import type * as utilities from "../src/object-types";
+import type * as utilities from "../src/object-types"
 
 describe("Readonly", () => {
     test("DeepReadonly for objects", () => {
         expectTypeOf<utilities.DeepReadonly<{ foo: string; bar: number }>>().toEqualTypeOf<{
-            readonly foo: string;
-            readonly bar: number;
-        }>();
+            readonly foo: string
+            readonly bar: number
+        }>()
         expectTypeOf<utilities.DeepReadonly<{ foo: string; bar: { foo: number } }>>().toEqualTypeOf<{
-            readonly foo: string;
-            readonly bar: { readonly foo: number };
-        }>();
+            readonly foo: string
+            readonly bar: { readonly foo: number }
+        }>()
         expectTypeOf<utilities.DeepReadonly<{ foo: { bar: string }; bar: { foo: number } }>>().toEqualTypeOf<{
-            readonly foo: { readonly bar: string };
-            readonly bar: { readonly foo: number };
-        }>();
-    });
-});
+            readonly foo: { readonly bar: string }
+            readonly bar: { readonly foo: number }
+        }>()
+    })
+})
 
 describe("Properties with keyof", () => {
     test("Combines keys of two object types", () => {
-        expectTypeOf<utilities.Properties<{ a: number }, { a: string }>>().toEqualTypeOf<"a">();
-        expectTypeOf<utilities.Properties<{ a: number }, { b: string }>>().toEqualTypeOf<"a" | "b">();
-        expectTypeOf<utilities.Properties<{ a: number }, { b: string; c: number }>>().toEqualTypeOf<"a" | "b" | "c">();
-    });
-});
+        expectTypeOf<utilities.Properties<{ a: number }, { a: string }>>().toEqualTypeOf<"a">()
+        expectTypeOf<utilities.Properties<{ a: number }, { b: string }>>().toEqualTypeOf<"a" | "b">()
+        expectTypeOf<utilities.Properties<{ a: number }, { b: string; c: number }>>().toEqualTypeOf<"a" | "b" | "c">()
+    })
+})
 
 describe("Merge values", () => {
     test("Union two object types", () => {
         expectTypeOf<utilities.Merge<{ a: number }, { b: string }>>().toEqualTypeOf<{
-            a: number;
-            b: string;
-        }>();
+            a: number
+            b: string
+        }>()
         expectTypeOf<utilities.Merge<{ a: number }, { b: string; c: boolean }>>().toEqualTypeOf<{
-            a: number;
-            b: string;
-            c: boolean;
-        }>();
-        expectTypeOf<utilities.Merge<{ a: number }, { a: string; b: string }>>().toEqualTypeOf<{ a: string; b: string }>();
-    });
-});
+            a: number
+            b: string
+            c: boolean
+        }>()
+        expectTypeOf<utilities.Merge<{ a: number }, { a: string; b: string }>>().toEqualTypeOf<{ a: string; b: string }>()
+    })
+})
 
 describe("FlattenProperties", () => {
     test("Extract property from object", () => {
         expectTypeOf<utilities.FlattenProperties<{ name: string; address: { street: string } }, "address">>().toEqualTypeOf<{
-            name: string;
-            street: string;
-        }>();
+            name: string
+            street: string
+        }>()
         expectTypeOf<
             utilities.FlattenProperties<{ name: string; address: { street: string; avenue: string } }, "address">
-        >().toEqualTypeOf<{ name: string; street: string; avenue: string }>();
-    });
-});
+        >().toEqualTypeOf<{ name: string; street: string; avenue: string }>()
+    })
+})
 
 describe("PublicOnly", () => {
     test("Remove properties beginning with (_)", () => {
         expectTypeOf<utilities.PublicOnly<{ foo: string }>>().toEqualTypeOf<{
-            foo: string;
-        }>();
-        expectTypeOf<utilities.PublicOnly<{ foo: string; _bar: string }>>().toEqualTypeOf<{ foo: string }>();
-        expectTypeOf<utilities.PublicOnly<{ _foo: string; _bar: string }>>().toEqualTypeOf<{}>();
-    });
-});
+            foo: string
+        }>()
+        expectTypeOf<utilities.PublicOnly<{ foo: string; _bar: string }>>().toEqualTypeOf<{ foo: string }>()
+        expectTypeOf<utilities.PublicOnly<{ _foo: string; _bar: string }>>().toEqualTypeOf<{}>()
+    })
+})
 
 describe("RetrieveKeyValue", () => {
     test("Exist the key within objects", () => {
-        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { bar: number }, "foo">>().toEqualTypeOf<string>();
-        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { bar: number }, "bar">>().toEqualTypeOf<number>();
-        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { foo: number }, "foo">>().toEqualTypeOf<string>();
-        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { foo: number }, "foobar">>().toEqualTypeOf<never>();
-    });
-});
+        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { bar: number }, "foo">>().toEqualTypeOf<string>()
+        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { bar: number }, "bar">>().toEqualTypeOf<number>()
+        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { foo: number }, "foo">>().toEqualTypeOf<string>()
+        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { foo: number }, "foobar">>().toEqualTypeOf<never>()
+    })
+})
 
 describe("RequiredByKeys", () => {
     test("Convert required properties in an object", () => {
         expectTypeOf<utilities.RequiredByKeys<{ foo?: string; bar?: number }, "foo">>().toEqualTypeOf<{
-            foo: string;
-            bar?: number;
-        }>();
+            foo: string
+            bar?: number
+        }>()
         expectTypeOf<utilities.RequiredByKeys<{ foo?: string; bar?: number }, "bar">>().toEqualTypeOf<{
-            foo?: string;
-            bar: number;
-        }>();
-        expectTypeOf<utilities.RequiredByKeys<{ foo?: string; bar?: number }>>().toEqualTypeOf<{ foo: string; bar: number }>();
-    });
-});
+            foo?: string
+            bar: number
+        }>()
+        expectTypeOf<utilities.RequiredByKeys<{ foo?: string; bar?: number }>>().toEqualTypeOf<{ foo: string; bar: number }>()
+    })
+})
 
 describe("UnionMerge", () => {
     test("Merge the types of the properties of two objects.", () => {
-        expectTypeOf<utilities.UnionMerge<{ foo: string }, { bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
-        expectTypeOf<utilities.UnionMerge<{ foo: string }, { foo: number }>>().toEqualTypeOf<{ foo: string | number }>();
+        expectTypeOf<utilities.UnionMerge<{ foo: string }, { bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>()
+        expectTypeOf<utilities.UnionMerge<{ foo: string }, { foo: number }>>().toEqualTypeOf<{ foo: string | number }>()
         expectTypeOf<utilities.UnionMerge<{ foo: string | number }, { foo: boolean }>>().toEqualTypeOf<{
-            foo: string | number | boolean;
-        }>();
-    });
-});
+            foo: string | number | boolean
+        }>()
+    })
+})
 
 describe("Mutable", () => {
     test("Converts properties to non readonly only one level", () => {
         expectTypeOf<utilities.Mutable<{ readonly foo: string }>>().toEqualTypeOf<{
-            foo: string;
-        }>();
+            foo: string
+        }>()
         expectTypeOf<
             utilities.Mutable<{
-                readonly foo: string;
-                readonly bar: { readonly foobar: number };
+                readonly foo: string
+                readonly bar: { readonly foobar: number }
             }>
-        >().toEqualTypeOf<{ foo: string; bar: { readonly foobar: number } }>();
-    });
-});
+        >().toEqualTypeOf<{ foo: string; bar: { readonly foobar: number } }>()
+    })
+})
 
 describe("DeepMutable", () => {
     test("Converts all properties to non readonly of an object type", () => {
@@ -118,269 +118,267 @@ describe("DeepMutable", () => {
                 { bar: string },
                 {
                     foobar: {
-                        foofoo: number;
-                    };
+                        foofoo: number
+                    }
                 },
-            ];
+            ]
         }
 
         interface Test6 {
             foo: {
                 bar: [
                     {
-                        foobar: string;
+                        foobar: string
                         barfoo: {
-                            foofoo: number;
-                        };
+                            foofoo: number
+                        }
                     },
-                ];
-            };
+                ]
+            }
         }
-        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: string }>>>().toEqualTypeOf<{ foo: string }>();
+        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: string }>>>().toEqualTypeOf<{ foo: string }>()
         expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: { bar: number } }>>>().toEqualTypeOf<{
-            foo: { bar: number };
-        }>();
+            foo: { bar: number }
+        }>()
         expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: { bar: { foobar: number } } }>>>().toEqualTypeOf<{
-            foo: { bar: { foobar: number } };
-        }>();
+            foo: { bar: { foobar: number } }
+        }>()
         expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: [{ bar: string; foobar: number }] }>>>().toEqualTypeOf<{
-            foo: [{ bar: string; foobar: number }];
-        }>();
-        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test5>>>().toEqualTypeOf<Test5>();
-        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test6>>>().toEqualTypeOf<Test6>();
-    });
-});
+            foo: [{ bar: string; foobar: number }]
+        }>()
+        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test5>>>().toEqualTypeOf<Test5>()
+        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test6>>>().toEqualTypeOf<Test6>()
+    })
+})
 
 describe("MergeAll", () => {
     test("Merge the properties of a tuple of objects", () => {
-        expectTypeOf<utilities.MergeAll<[{ foo: string }, { bar: number }]>>().toEqualTypeOf<{ foo: string; bar: number }>();
+        expectTypeOf<utilities.MergeAll<[{ foo: string }, { bar: number }]>>().toEqualTypeOf<{ foo: string; bar: number }>()
         expectTypeOf<utilities.MergeAll<[{ foo: string }, { bar: { foobar: number } }]>>().toEqualTypeOf<{
-            foo: string;
-            bar: { foobar: number };
-        }>();
+            foo: string
+            bar: { foobar: number }
+        }>()
         type Expect3 = {
-            foo: string | boolean;
-            bar: number | string;
-            foobar: string;
-        };
+            foo: string | boolean
+            bar: number | string
+            foobar: string
+        }
         expectTypeOf<
             utilities.MergeAll<[{ foo: string }, { bar: string }, { bar: number; foo: boolean; foobar: string }]>
-        >().toEqualTypeOf<Expect3>();
-    });
-});
+        >().toEqualTypeOf<Expect3>()
+    })
+})
 
 describe("ToUnion", () => {
     test("Create an union type", () => {
-        expectTypeOf<utilities.ToUnion<12>>().toEqualTypeOf<12>();
-        expectTypeOf<utilities.ToUnion<"foo">>().toEqualTypeOf<"foo">();
-        expectTypeOf<utilities.ToUnion<12 | 21>>().toEqualTypeOf<12 | 21>();
-        expectTypeOf<utilities.ToUnion<[12, 21, "foo"]>>().toEqualTypeOf<12 | 21 | "foo" | []>();
-    });
-});
+        expectTypeOf<utilities.ToUnion<12>>().toEqualTypeOf<12>()
+        expectTypeOf<utilities.ToUnion<"foo">>().toEqualTypeOf<"foo">()
+        expectTypeOf<utilities.ToUnion<12 | 21>>().toEqualTypeOf<12 | 21>()
+        expectTypeOf<utilities.ToUnion<[12, 21, "foo"]>>().toEqualTypeOf<12 | 21 | "foo" | []>()
+    })
+})
 
 describe("AddPropertyToObject", () => {
     test("Append a new property of an exist object type", () => {
         expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", number>>().toEqualTypeOf<{
-            foo: string;
-            bar: number;
-        }>();
+            foo: string
+            bar: number
+        }>()
         expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", { foobar: number; barfoo: boolean }>>().toEqualTypeOf<{
-            foo: string;
-            bar: { foobar: number; barfoo: boolean };
-        }>();
+            foo: string
+            bar: { foobar: number; barfoo: boolean }
+        }>()
         expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", [1, 2, 3]>>().toEqualTypeOf<{
-            foo: string;
-            bar: [1, 2, 3];
-        }>();
+            foo: string
+            bar: [1, 2, 3]
+        }>()
         expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", string | boolean | number>>().toEqualTypeOf<{
-            foo: string;
-            bar: string | boolean | number;
-        }>();
-    });
-});
+            foo: string
+            bar: string | boolean | number
+        }>()
+    })
+})
 
 describe("Intersection", () => {
     test("Intersection of properties between two objects", () => {
-        expectTypeOf<utilities.Intersection<{ foo: string }, { foo: number; bar: boolean }>>().toEqualTypeOf<{ bar: boolean }>();
-        expectTypeOf<utilities.Intersection<{ foo: string; bar: boolean }, { bar: number; foo: bigint }>>().toEqualTypeOf<{}>();
+        expectTypeOf<utilities.Intersection<{ foo: string }, { foo: number; bar: boolean }>>().toEqualTypeOf<{ bar: boolean }>()
+        expectTypeOf<utilities.Intersection<{ foo: string; bar: boolean }, { bar: number; foo: bigint }>>().toEqualTypeOf<{}>()
         expectTypeOf<
             utilities.Intersection<{ foo: string; bar: { bar: number } }, { barfoo: { bar: number }; foo: bigint }>
-        >().toEqualTypeOf<{ bar: { bar: number }; barfoo: { bar: number } }>();
-    });
-});
+        >().toEqualTypeOf<{ bar: { bar: number }; barfoo: { bar: number } }>()
+    })
+})
 
 describe("Omit Properties", () => {
     describe("Omit", () => {
         test("Omit the properties based on the key type", () => {
             expectTypeOf<Omit<{ foo: string }, "">>().toEqualTypeOf<{
-                foo: string;
-            }>();
-            expectTypeOf<Omit<{ foo: string; bar: number }, "foo">>().toEqualTypeOf<{ bar: number }>();
+                foo: string
+            }>()
+            expectTypeOf<Omit<{ foo: string; bar: number }, "foo">>().toEqualTypeOf<{ bar: number }>()
             expectTypeOf<Omit<{ foo: () => void; bar: { foobar: number } }, "foo">>().toEqualTypeOf<{
-                bar: { foobar: number };
-            }>();
-        });
-    });
+                bar: { foobar: number }
+            }>()
+        })
+    })
 
     describe("OmitByType", () => {
         test("Omit the properties based on the type", () => {
             expectTypeOf<utilities.OmitByType<{ foo: string; bar: string; foobar: number }, string>>().toEqualTypeOf<{
-                foobar: number;
-            }>();
+                foobar: number
+            }>()
             expectTypeOf<utilities.OmitByType<{ foo: string; bar: number; foobar: boolean }, string | boolean>>().toEqualTypeOf<{
-                bar: number;
-            }>();
+                bar: number
+            }>()
             expectTypeOf<
                 utilities.OmitByType<
                     {
-                        foo: () => void;
-                        bar: () => void;
-                        foobar: { barbar: number };
+                        foo: () => void
+                        bar: () => void
+                        foobar: { barbar: number }
                     },
                     () => void
                 >
-            >().toEqualTypeOf<{ foobar: { barbar: number } }>();
-        });
-    });
-});
+            >().toEqualTypeOf<{ foobar: { barbar: number } }>()
+        })
+    })
+})
 
 describe("Parameters", () => {
     test("Returns the parameters of a function", () => {
-        expectTypeOf<utilities.Parameters<() => void>>().toEqualTypeOf<[]>();
-        expectTypeOf<utilities.Parameters<(foo: string) => void>>().toEqualTypeOf<[string]>();
-        expectTypeOf<utilities.Parameters<(foo: string, bar: number) => void>>().toEqualTypeOf<[string, number]>();
-        expectTypeOf<utilities.Parameters<(foo: { bar: number }) => void>>().toEqualTypeOf<[{ bar: number }]>();
-    });
-});
+        expectTypeOf<utilities.Parameters<() => void>>().toEqualTypeOf<[]>()
+        expectTypeOf<utilities.Parameters<(foo: string) => void>>().toEqualTypeOf<[string]>()
+        expectTypeOf<utilities.Parameters<(foo: string, bar: number) => void>>().toEqualTypeOf<[string, number]>()
+        expectTypeOf<utilities.Parameters<(foo: { bar: number }) => void>>().toEqualTypeOf<[{ bar: number }]>()
+    })
+})
 
 describe("Includes", () => {
     test("Check if an element exist withins a tuple", () => {
-        expectTypeOf<utilities.Includes<[], any>>().toEqualTypeOf<false>();
-        expectTypeOf<utilities.Includes<[1, 2, "foo", "bar"], 2>>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.Includes<["foo", "bar", () => void, {}], () => void>>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.Includes<[string, 1, () => void, {}], string>>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.Includes<[string, number, () => void, {}], number>>().toEqualTypeOf<true>();
-        expectTypeOf<utilities.Includes<[true, false, true], number>>().toEqualTypeOf<false>();
-    });
-});
+        expectTypeOf<utilities.Includes<[], any>>().toEqualTypeOf<false>()
+        expectTypeOf<utilities.Includes<[1, 2, "foo", "bar"], 2>>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.Includes<["foo", "bar", () => void, {}], () => void>>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.Includes<[string, 1, () => void, {}], string>>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.Includes<[string, number, () => void, {}], number>>().toEqualTypeOf<true>()
+        expectTypeOf<utilities.Includes<[true, false, true], number>>().toEqualTypeOf<false>()
+    })
+})
 
 describe("ObjectEntries", () => {
     test("Returns the entries from an object", () => {
-        expectTypeOf<utilities.ObjectEntries<{ foo: string }>>().toEqualTypeOf<["foo", string]>();
-        expectTypeOf<utilities.ObjectEntries<{ foo?: string }>>().toEqualTypeOf<["foo", string]>();
-        expectTypeOf<utilities.ObjectEntries<{ foo?: string; bar?: number }>>().toEqualTypeOf<
-            ["foo", string] | ["bar", number]
-        >();
+        expectTypeOf<utilities.ObjectEntries<{ foo: string }>>().toEqualTypeOf<["foo", string]>()
+        expectTypeOf<utilities.ObjectEntries<{ foo?: string }>>().toEqualTypeOf<["foo", string]>()
+        expectTypeOf<utilities.ObjectEntries<{ foo?: string; bar?: number }>>().toEqualTypeOf<["foo", string] | ["bar", number]>()
         expectTypeOf<utilities.ObjectEntries<{ foo?: undefined; bar: undefined | string }>>().toEqualTypeOf<
             ["foo", undefined] | ["bar", undefined | string]
-        >();
-    });
-});
+        >()
+    })
+})
 
 describe("Pick Utilities", () => {
     describe("Pick", () => {
         test("Pick by keys", () => {
-            expectTypeOf<Pick<{ foo: string; bar: number }, never>>().toEqualTypeOf<{}>();
-            expectTypeOf<Pick<{ foo: string; bar: number }, "bar">>().toEqualTypeOf<{ bar: number }>();
-            expectTypeOf<Pick<{ foo: string; bar: number }, "bar" | "foo">>().toEqualTypeOf<{ foo: string; bar: number }>();
-        });
-    });
+            expectTypeOf<Pick<{ foo: string; bar: number }, never>>().toEqualTypeOf<{}>()
+            expectTypeOf<Pick<{ foo: string; bar: number }, "bar">>().toEqualTypeOf<{ bar: number }>()
+            expectTypeOf<Pick<{ foo: string; bar: number }, "bar" | "foo">>().toEqualTypeOf<{ foo: string; bar: number }>()
+        })
+    })
 
     describe("PickByType", () => {
         test("Pick by type", () => {
             expectTypeOf<utilities.PickByType<{ foo: string; bar: number; foofoo: string }, number>>().toEqualTypeOf<{
-                bar: number;
-            }>();
+                bar: number
+            }>()
             expectTypeOf<utilities.PickByType<{ foo: string; bar: number; foofoo: string }, string>>().toEqualTypeOf<{
-                foo: string;
-                foofoo: string;
-            }>();
-            expectTypeOf<utilities.PickByType<{ foo: () => {}; bar: number }, string>>().toEqualTypeOf<{}>();
-            expectTypeOf<utilities.PickByType<{ foo: () => {}; bar: number; foobar: {} }, never>>().toEqualTypeOf<{}>();
+                foo: string
+                foofoo: string
+            }>()
+            expectTypeOf<utilities.PickByType<{ foo: () => {}; bar: number }, string>>().toEqualTypeOf<{}>()
+            expectTypeOf<utilities.PickByType<{ foo: () => {}; bar: number; foobar: {} }, never>>().toEqualTypeOf<{}>()
             expectTypeOf<utilities.PickByType<{ foo: () => {}; bar: number; foobar: {} }, () => {}>>().toEqualTypeOf<{
-                foo: () => {};
-            }>();
-        });
-    });
-});
+                foo: () => {}
+            }>()
+        })
+    })
+})
 
 describe("ReplaceKeys", () => {
     test("Replace the key types", () => {
         expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "bar", { bar: string }>>().toEqualTypeOf<{
-            foo: string;
-            bar: string;
-        }>();
+            foo: string
+            bar: string
+        }>()
         expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "foobar", { bar: string }>>().toEqualTypeOf<{
-            foo: string;
-            bar: number;
-        }>();
+            foo: string
+            bar: number
+        }>()
         expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "bar", { foobar: string }>>().toEqualTypeOf<{
-            foo: string;
-            bar: unknown;
-        }>();
+            foo: string
+            bar: unknown
+        }>()
         expectTypeOf<
             utilities.ReplaceKeys<{ foo: string; bar: number }, "foo" | "bar", { foo: number; bar: boolean }>
         >().toEqualTypeOf<{
-            foo: number;
-            bar: boolean;
-        }>();
-    });
-});
+            foo: number
+            bar: boolean
+        }>()
+    })
+})
 
 describe("MapTypes", () => {
     test("Replace the types of the keys that match with Mapper type", () => {
         expectTypeOf<utilities.MapTypes<{ foo: string; bar: number }, { from: string; to: number }>>().toEqualTypeOf<{
-            foo: number;
-            bar: number;
-        }>();
+            foo: number
+            bar: number
+        }>()
         expectTypeOf<utilities.MapTypes<{ foo: number; bar: number }, { from: number; to: string }>>().toEqualTypeOf<{
-            foo: string;
-            bar: string;
-        }>();
+            foo: string
+            bar: string
+        }>()
         expectTypeOf<utilities.MapTypes<{ foo: string; bar: number }, { from: boolean; to: number }>>().toEqualTypeOf<{
-            foo: string;
-            bar: number;
-        }>();
+            foo: string
+            bar: number
+        }>()
         expectTypeOf<utilities.MapTypes<{ foo: () => {}; bar: string }, { from: () => {}; to: never }>>().toEqualTypeOf<{
-            foo: never;
-            bar: string;
-        }>();
+            foo: never
+            bar: string
+        }>()
         expectTypeOf<
             utilities.MapTypes<{ foo: string; bar: number }, { from: string; to: boolean } | { from: number; to: bigint }>
-        >().toEqualTypeOf<{ foo: boolean; bar: bigint }>();
-    });
-});
+        >().toEqualTypeOf<{ foo: boolean; bar: bigint }>()
+    })
+})
 
 describe("DeepOmit", () => {
     test("Omit properties from nested objects", () => {
         expectTypeOf<utilities.DeepOmit<{ foo: string; bar: { foobar: number } }, "foo">>().toEqualTypeOf<{
-            bar: { foobar: number };
-        }>();
+            bar: { foobar: number }
+        }>()
         expectTypeOf<utilities.DeepOmit<{ foo: string; bar: { foobar: number } }, "bar.foobar">>().toEqualTypeOf<{
-            foo: string;
-            bar: {};
-        }>();
+            foo: string
+            bar: {}
+        }>()
         expectTypeOf<utilities.DeepOmit<{ foo: string; bar: { foobar: number } }, "foobar">>().toEqualTypeOf<{
-            foo: string;
-            bar: { foobar: number };
-        }>();
+            foo: string
+            bar: { foobar: number }
+        }>()
         expectTypeOf<
             utilities.DeepOmit<{ foo: string; bar: { foobar: number; nested: { baz: string } } }, "bar.nested.baz">
         >().toEqualTypeOf<{
-            foo: string;
-            bar: { foobar: number; nested: {} };
-        }>();
-    });
-});
+            foo: string
+            bar: { foobar: number; nested: {} }
+        }>()
+    })
+})
 
 describe("ToPrimitive", () => {
     test("Converts a string to a primitive type", () => {
-        expectTypeOf<utilities.ToPrimitive<{ foo: string; bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
-        expectTypeOf<utilities.ToPrimitive<{ foo: "foobar"; bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>();
-        expectTypeOf<utilities.ToPrimitive<{ foo: "foobar"; bar: 12 }>>().toEqualTypeOf<{ foo: string; bar: number }>();
+        expectTypeOf<utilities.ToPrimitive<{ foo: string; bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>()
+        expectTypeOf<utilities.ToPrimitive<{ foo: "foobar"; bar: string }>>().toEqualTypeOf<{ foo: string; bar: string }>()
+        expectTypeOf<utilities.ToPrimitive<{ foo: "foobar"; bar: 12 }>>().toEqualTypeOf<{ foo: string; bar: number }>()
         expectTypeOf<utilities.ToPrimitive<{ foo: { foobar: "fo"; bar: false }; bar: 12 }>>().toEqualTypeOf<{
-            foo: { foobar: string; bar: boolean };
-            bar: number;
-        }>();
-    });
-});
+            foo: { foobar: string; bar: boolean }
+            bar: number
+        }>()
+    })
+})

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -1,43 +1,43 @@
-import { describe, test, expectTypeOf } from "vitest";
-import type * as utilities from "../src/utils";
+import { describe, test, expectTypeOf } from "vitest"
+import type * as utilities from "../src/utils"
 
 describe("PercentageParser", () => {
     test("Parses a percentage string into a tuple", () => {
-        expectTypeOf<utilities.PercentageParser<"foobar">>().toEqualTypeOf<never>();
-        expectTypeOf<utilities.PercentageParser<"2024">>().toEqualTypeOf<["", "2024", ""]>();
-        expectTypeOf<utilities.PercentageParser<"-89">>().toEqualTypeOf<["-", "89", ""]>();
-        expectTypeOf<utilities.PercentageParser<"+89%">>().toEqualTypeOf<["+", "89", "%"]>();
-    });
-});
+        expectTypeOf<utilities.PercentageParser<"foobar">>().toEqualTypeOf<never>()
+        expectTypeOf<utilities.PercentageParser<"2024">>().toEqualTypeOf<["", "2024", ""]>()
+        expectTypeOf<utilities.PercentageParser<"-89">>().toEqualTypeOf<["-", "89", ""]>()
+        expectTypeOf<utilities.PercentageParser<"+89%">>().toEqualTypeOf<["+", "89", "%"]>()
+    })
+})
 
 describe("Absolute", () => {
     test("Returns the absolute version of a number", () => {
-        expectTypeOf<utilities.Absolute<-100>>().toEqualTypeOf<"100">();
-        expectTypeOf<utilities.Absolute<-0>>().toEqualTypeOf<"0">();
-        expectTypeOf<utilities.Absolute<-999_999_999_999>>().toEqualTypeOf<"999999999999">();
-        expectTypeOf<utilities.Absolute<-999_999_999_999_999n>>().toEqualTypeOf<"999999999999999">();
-    });
-});
+        expectTypeOf<utilities.Absolute<-100>>().toEqualTypeOf<"100">()
+        expectTypeOf<utilities.Absolute<-0>>().toEqualTypeOf<"0">()
+        expectTypeOf<utilities.Absolute<-999_999_999_999>>().toEqualTypeOf<"999999999999">()
+        expectTypeOf<utilities.Absolute<-999_999_999_999_999n>>().toEqualTypeOf<"999999999999999">()
+    })
+})
 
 describe("Trunc", () => {
     test("Truncate a number to its integer part", () => {
-        expectTypeOf<utilities.Trunc<3.14159>>().toEqualTypeOf<"3">();
-        expectTypeOf<utilities.Trunc<-3.14159>>().toEqualTypeOf<"-3">();
-        expectTypeOf<utilities.Trunc<42.1>>().toEqualTypeOf<"42">();
-        expectTypeOf<utilities.Trunc<0>>().toEqualTypeOf<"0">();
-        expectTypeOf<utilities.Trunc<1289n>>().toEqualTypeOf<"1289">();
-        expectTypeOf<utilities.Trunc<-0.98>>().toEqualTypeOf<"0">();
-        expectTypeOf<utilities.Trunc<-90000.98>>().toEqualTypeOf<"-90000">();
-    });
-});
+        expectTypeOf<utilities.Trunc<3.14159>>().toEqualTypeOf<"3">()
+        expectTypeOf<utilities.Trunc<-3.14159>>().toEqualTypeOf<"-3">()
+        expectTypeOf<utilities.Trunc<42.1>>().toEqualTypeOf<"42">()
+        expectTypeOf<utilities.Trunc<0>>().toEqualTypeOf<"0">()
+        expectTypeOf<utilities.Trunc<1289n>>().toEqualTypeOf<"1289">()
+        expectTypeOf<utilities.Trunc<-0.98>>().toEqualTypeOf<"0">()
+        expectTypeOf<utilities.Trunc<-90000.98>>().toEqualTypeOf<"-90000">()
+    })
+})
 
 describe("NumberRange", () => {
     test("Create a union type with a range of numbers", () => {
-        expectTypeOf<utilities.NumberRange<1, 5>>().toEqualTypeOf<1 | 2 | 3 | 4 | 5>();
-        expectTypeOf<utilities.NumberRange<9, 14>>().toEqualTypeOf<9 | 10 | 11 | 12 | 13 | 14>();
-        expectTypeOf<utilities.NumberRange<-5, 5>>().toEqualTypeOf<never>();
-        expectTypeOf<utilities.NumberRange<0, 0>>().toEqualTypeOf<0>();
-        expectTypeOf<utilities.NumberRange<-5, -5>>().toEqualTypeOf<never>();
-        expectTypeOf<utilities.NumberRange<-5, 0>>().toEqualTypeOf<never>();
-    });
-});
+        expectTypeOf<utilities.NumberRange<1, 5>>().toEqualTypeOf<1 | 2 | 3 | 4 | 5>()
+        expectTypeOf<utilities.NumberRange<9, 14>>().toEqualTypeOf<9 | 10 | 11 | 12 | 13 | 14>()
+        expectTypeOf<utilities.NumberRange<-5, 5>>().toEqualTypeOf<never>()
+        expectTypeOf<utilities.NumberRange<0, 0>>().toEqualTypeOf<0>()
+        expectTypeOf<utilities.NumberRange<-5, -5>>().toEqualTypeOf<never>()
+        expectTypeOf<utilities.NumberRange<-5, 0>>().toEqualTypeOf<never>()
+    })
+})

--- a/test/validate-types.test.ts
+++ b/test/validate-types.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from "vitest";
+import { describe, test, expect } from "vitest"
 import {
     isPrimitive,
     isPrimitiveNullish,
@@ -8,128 +8,128 @@ import {
     isObject,
     isArray,
     isFunction,
-} from "./../src/validate-types";
+} from "./../src/validate-types"
 
 describe("Primitive Validation", () => {
     describe("isPrimitive", () => {
         test("should return true for primitive values", ({}) => {
-            expect(isPrimitive(1)).toBeTruthy();
-            expect(isPrimitive("str")).toBeTruthy();
-            expect(isPrimitive(true)).toBeTruthy();
-            expect(isPrimitive(BigInt(12))).toBeTruthy();
-            expect(isPrimitive(Symbol("sym"))).toBeTruthy();
-        });
+            expect(isPrimitive(1)).toBeTruthy()
+            expect(isPrimitive("str")).toBeTruthy()
+            expect(isPrimitive(true)).toBeTruthy()
+            expect(isPrimitive(BigInt(12))).toBeTruthy()
+            expect(isPrimitive(Symbol("sym"))).toBeTruthy()
+        })
 
         test("should return false for primitive values", () => {
-            expect(isPrimitive(null)).toBeFalsy();
-            expect(isPrimitive(undefined)).toBeFalsy();
-            expect(isPrimitive({})).toBeFalsy();
-            expect(isPrimitive(() => {})).toBeFalsy();
-        });
-    });
+            expect(isPrimitive(null)).toBeFalsy()
+            expect(isPrimitive(undefined)).toBeFalsy()
+            expect(isPrimitive({})).toBeFalsy()
+            expect(isPrimitive(() => {})).toBeFalsy()
+        })
+    })
 
     describe("isPrimitiveNullish", () => {
         test("should return true for primitive values including null and undefined", () => {
-            expect(isPrimitiveNullish(1)).toBeTruthy();
-            expect(isPrimitiveNullish("str")).toBeTruthy();
-            expect(isPrimitiveNullish(true)).toBeTruthy();
-            expect(isPrimitiveNullish(BigInt(12))).toBeTruthy();
-            expect(isPrimitiveNullish(Symbol("symbol"))).toBeTruthy();
-            expect(isPrimitiveNullish(null)).toBeTruthy();
-            expect(isPrimitiveNullish(undefined)).toBeTruthy();
-        });
+            expect(isPrimitiveNullish(1)).toBeTruthy()
+            expect(isPrimitiveNullish("str")).toBeTruthy()
+            expect(isPrimitiveNullish(true)).toBeTruthy()
+            expect(isPrimitiveNullish(BigInt(12))).toBeTruthy()
+            expect(isPrimitiveNullish(Symbol("symbol"))).toBeTruthy()
+            expect(isPrimitiveNullish(null)).toBeTruthy()
+            expect(isPrimitiveNullish(undefined)).toBeTruthy()
+        })
         test("should return false for non-primitive values", () => {
-            expect(isPrimitive({})).toBeFalsy();
-            expect(isPrimitive(() => {})).toBeFalsy();
-        });
-    });
-});
+            expect(isPrimitive({})).toBeFalsy()
+            expect(isPrimitive(() => {})).toBeFalsy()
+        })
+    })
+})
 
 describe("Types validation", () => {
     describe("isNumber", () => {
         test("should return true for numbers", () => {
-            expect(isNumber(1)).toBeTruthy();
-        });
+            expect(isNumber(1)).toBeTruthy()
+        })
 
         test("should return false for non-numbers", () => {
-            expect(isNumber(false)).toBeFalsy();
-            expect(isNumber("str")).toBeFalsy();
-            expect(isNumber(null)).toBeFalsy();
-            expect(isNumber(undefined)).toBeFalsy();
-            expect(isNumber({})).toBeFalsy();
-        });
-    });
+            expect(isNumber(false)).toBeFalsy()
+            expect(isNumber("str")).toBeFalsy()
+            expect(isNumber(null)).toBeFalsy()
+            expect(isNumber(undefined)).toBeFalsy()
+            expect(isNumber({})).toBeFalsy()
+        })
+    })
 
     describe("isBoolean", () => {
         test("should return true for booleans", () => {
-            expect(isBoolean(false)).toBeTruthy();
-        });
+            expect(isBoolean(false)).toBeTruthy()
+        })
 
         test("should return false for non-booleans", () => {
-            expect(isBoolean(1)).toBeFalsy();
-            expect(isBoolean("str")).toBeFalsy();
-            expect(isBoolean(null)).toBeFalsy();
-            expect(isBoolean(undefined)).toBeFalsy();
-            expect(isBoolean({})).toBeFalsy();
-        });
-    });
+            expect(isBoolean(1)).toBeFalsy()
+            expect(isBoolean("str")).toBeFalsy()
+            expect(isBoolean(null)).toBeFalsy()
+            expect(isBoolean(undefined)).toBeFalsy()
+            expect(isBoolean({})).toBeFalsy()
+        })
+    })
 
     describe("isString", () => {
         test("should return true for strings", () => {
-            expect(isString("str")).toBeTruthy();
-        });
+            expect(isString("str")).toBeTruthy()
+        })
 
         test("should return false for non-strings", () => {
-            expect(isString(1)).toBeFalsy();
-            expect(isString(false)).toBeFalsy();
-            expect(isString(null)).toBeFalsy();
-            expect(isString(undefined)).toBeFalsy();
-            expect(isString({})).toBeFalsy();
-        });
-    });
+            expect(isString(1)).toBeFalsy()
+            expect(isString(false)).toBeFalsy()
+            expect(isString(null)).toBeFalsy()
+            expect(isString(undefined)).toBeFalsy()
+            expect(isString({})).toBeFalsy()
+        })
+    })
 
     describe("isObject", () => {
         test("should return true for objects", () => {
-            expect(isObject({})).toBeTruthy();
-        });
+            expect(isObject({})).toBeTruthy()
+        })
 
         test("should return false for non-objects", () => {
-            expect(isObject(1)).toBeFalsy();
-            expect(isObject(false)).toBeFalsy();
-            expect(isObject("str")).toBeFalsy();
-            expect(isObject(null)).toBeFalsy();
-            expect(isObject(undefined)).toBeFalsy();
-            expect(isObject(() => {})).toBeFalsy();
-        });
-    });
+            expect(isObject(1)).toBeFalsy()
+            expect(isObject(false)).toBeFalsy()
+            expect(isObject("str")).toBeFalsy()
+            expect(isObject(null)).toBeFalsy()
+            expect(isObject(undefined)).toBeFalsy()
+            expect(isObject(() => {})).toBeFalsy()
+        })
+    })
 
     describe("isArray", () => {
         test("should return true for arrays", () => {
-            expect(isArray([])).toBeTruthy();
-            expect(isArray([1, 2, 3])).toBeTruthy();
-            expect(isArray(new Array(3))).toBeTruthy();
-        });
+            expect(isArray([])).toBeTruthy()
+            expect(isArray([1, 2, 3])).toBeTruthy()
+            expect(isArray(new Array(3))).toBeTruthy()
+        })
 
         test("should return false for non-arrays", () => {
-            expect(isArray(1)).toBeFalsy();
-            expect(isArray(false)).toBeFalsy();
-            expect(isArray("str")).toBeFalsy();
-            expect(isArray(null)).toBeFalsy();
-            expect(isArray(undefined)).toBeFalsy();
-        });
-    });
+            expect(isArray(1)).toBeFalsy()
+            expect(isArray(false)).toBeFalsy()
+            expect(isArray("str")).toBeFalsy()
+            expect(isArray(null)).toBeFalsy()
+            expect(isArray(undefined)).toBeFalsy()
+        })
+    })
 
     describe("isFunction", () => {
         test("should return true for functions", () => {
-            expect(isFunction(() => {})).toBeTruthy();
-        });
+            expect(isFunction(() => {})).toBeTruthy()
+        })
 
         test("should return false for non-functions", () => {
-            expect(isFunction(1)).toBeFalsy();
-            expect(isFunction(false)).toBeFalsy();
-            expect(isFunction("str")).toBeFalsy();
-            expect(isFunction(null)).toBeFalsy();
-            expect(isFunction(undefined)).toBeFalsy();
-        });
-    });
-});
+            expect(isFunction(1)).toBeFalsy()
+            expect(isFunction(false)).toBeFalsy()
+            expect(isFunction("str")).toBeFalsy()
+            expect(isFunction(null)).toBeFalsy()
+            expect(isFunction(undefined)).toBeFalsy()
+        })
+    })
+})

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "tsup";
+import { defineConfig } from "tsup"
 
 /**
  * Configuration for the tsup bundler. This configuration specifies two main entry points
@@ -25,4 +25,4 @@ export const tsup = defineConfig([
         minify: true,
         clean: true,
     },
-]);
+])

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig } from "vitest/config"
 
 export default defineConfig({
     test: {
@@ -10,4 +10,4 @@ export default defineConfig({
             reportsDirectory: "test/coverage",
         },
     },
-});
+})


### PR DESCRIPTION
## Description
This pull request updates the `semi` property in the Prettier configuration found in the `package.json` file. Additionally, the `format` script is executed to apply the updated formatting rules across the codebase.

### Changes
- Updated the `semi` field in Prettier configuration (`package.json`).
- Ran the `format` script to apply the formatting changes to the codebase.


## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->