### PR TITLE
chore: add entry points to `exports` field in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "vitest --run",
     "test:watch": "vitest",
     "test:coverage": "vitest --coverage",
-    "build": "tsup",
+    "build": "tsup && tsup src/validate-types.ts --dts --format esm,cjs --outDir dist/utils",
     "publish": "npm run build",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
@@ -48,10 +48,31 @@
       "import": "./dist/index.d.ts",
       "require": "./dist/index.d.ts"
     },
-    "./utils": {
+    "./validate": {
       "types": "./dist/utils/validate-types.d.ts",
       "import": "./dist/utils/validate-types.js",
       "require": "./dist/utils/validate-types.cjs"
+    },
+    "./arrays": {
+      "types": "./dist/array-types.d.ts"
+    },
+    "./objects": {
+      "types": "./dist/object-types.d.ts"
+    },
+    "./string-mappers": {
+      "types": "./dist/string-mappers.d.ts"
+    },
+    "./test": {
+      "types": "./dist/test.d.ts"
+    },
+    "./type-guards": {
+      "types": "./dist/type-guards.d.ts"
+    },
+    "./types": {
+      "types": "./dist/types.d.ts"
+    },
+    "./utilities": {
+      "types": "./dist/utility-types.d.ts"
     }
   },
   "files": [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -6,23 +6,13 @@ import { defineConfig } from "tsup"
  * the .d.ts files. The second entry point handles files that need to be built in both .js and
  * .cjs formats.
  */
-export const tsup = defineConfig([
-    {
-        entry: ["src", "!src/validate-types.ts"],
-        format: ["esm"],
-        outDir: "dist",
-        dts: {
-            only: true,
-        },
-        minify: true,
-        clean: true,
+export const tsup = defineConfig({
+    entry: ["src", "!src/validate-types.ts"],
+    format: ["esm"],
+    outDir: "dist",
+    dts: {
+        only: true,
     },
-    {
-        entry: ["src/validate-types.ts"],
-        format: ["esm", "cjs"],
-        outDir: "dist/utils",
-        dts: true,
-        minify: true,
-        clean: true,
-    },
-])
+    minify: true,
+    clean: true,
+})


### PR DESCRIPTION


## Description
This pull request adds new entry points to the `exports` field in `package.json`, allowing the package to export specific files based on their responsibilities and usage requirements. The goal of these changes is to improve performance by enabling users to import only the types they need, rather than importing all types from the package.

### Key Changes
- Updated `tsup.config.ts` to support the new entry points.
- Modified `build` script in `package.json` to reflect the changes in module exports.



## Checklist
- [ ]  Added documentation.
- [x]  The changes do not generate any warnings.
- [x]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->