### PR TITLE
feat: add `CompareArrayLength` type

### DIFF
--- a/src/array-types.ts
+++ b/src/array-types.ts
@@ -271,3 +271,15 @@ export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = ZipImpleme
  * type Flatten2 = FlattenArrayType<string[][][]>;
  */
 export type FlattenArrayType<Array> = Array extends (infer Type)[] ? FlattenArrayType<Type> : Array
+
+/**
+ * Compare the length of two arrays, returning 1 if the first array is longer,
+ * -1 if the second array is longer, and 0 if they are equal
+ */
+export type CompareArrayLength<T extends any[], U extends any[]> = T extends [any, ...infer SpreadT]
+    ? U extends [any, ...infer SpreadU]
+        ? CompareArrayLength<SpreadT, SpreadU>
+        : 1
+    : U extends [infer Item, ...infer Spread]
+      ? -1
+      : 0

--- a/test/array-types.test.ts
+++ b/test/array-types.test.ts
@@ -82,6 +82,14 @@ describe("Tuple methods", () => {
             expectTypeOf<utilities.LastIndexOf<[string, any, 1, number, "a", any, 1], any>>().toEqualTypeOf<5>()
         })
     })
+
+    describe("CompareArrayLength", () => {
+        test("Compare the length of two arrays", () => {
+            expectTypeOf<utilities.CompareArrayLength<[1, 2, 3], [1, 2, 3]>>().toEqualTypeOf<0>()
+            expectTypeOf<utilities.CompareArrayLength<[1, 2, 3], [1, 2]>>().toEqualTypeOf<1>()
+            expectTypeOf<utilities.CompareArrayLength<[1, 2], [1, 2, 3]>>().toEqualTypeOf<-1>()
+        })
+    })
 })
 
 describe("ConstructTuple", () => {


### PR DESCRIPTION
## Description
This pull request introduces a new type called `CompareArrayLength` that compares the lengths of two arrays. It returns:
- `1` if the first array is longer than the second,
- `0` if the arrays have the same length,
- `-1` if the first array is shorter than the second.

## Checklist
- [ ]  Added documentation.
- [ ]  The changes do not generate any warnings.
- [ ]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->