### PR TITLE
chore: update `coverage`

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "tsup --watch",
     "test": "vitest --run",
     "test:watch": "vitest",
-    "test:coverage": "vitest --coverage",
+    "test:coverage": "vitest run --coverage",
     "build": "tsup && tsup src/validate-types.ts --dts --format esm,cjs --outDir dist/utils",
     "publish": "npm run build",
     "format": "prettier --write .",
@@ -36,11 +36,11 @@
   "homepage": "https://github.com/halvaradop/ts-utility-types#readme",
   "devDependencies": {
     "@types/node": "^22.5.3",
-    "@vitest/coverage-v8": "^2.1.1",
+    "@vitest/coverage-v8": "^2.1.6",
     "prettier": "^3.3.3",
     "tsup": "^8.2.4",
     "typescript": "^5.5.4",
-    "vitest": "^2.0.5"
+    "vitest": "^2.1.6"
   },
   "exports": {
     ".": {

--- a/test/object-types.test.ts
+++ b/test/object-types.test.ts
@@ -1,5 +1,4 @@
 import { describe, test, expectTypeOf } from "vitest"
-//import type * as utilities from "../src/utility-types";
 import type * as utilities from "../src/object-types"
 
 describe("Readonly", () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,8 +4,6 @@ export default defineConfig({
     test: {
         coverage: {
             provider: "v8",
-            include: ["test/**/*.test.ts"],
-            exclude: ["node_modules", "dist"],
             reporter: ["text", "html"],
             reportsDirectory: "test/coverage",
         },


### PR DESCRIPTION
## Description

This pull request cleans up the test coverage in the codebase by removing unnecessary properties and improving the `test:coverage` script in `package.json` to execute the coverage report only once without watching for changes, thus avoiding re-executing the test coverage every time files are saved.

Additionally, it acknowledges that test coverage is not necessary for files containing utility types, as types and interfaces are static files and do not generate executable code, and therefore are not recognized by the test coverage.


## Checklist
- [ ]  Added documentation.
- [ ]  The changes do not generate any warnings.
- [ ]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->