### PR TITLE
feat: add `GetOptional` type

### DIFF
--- a/src/object-types.ts
+++ b/src/object-types.ts
@@ -542,3 +542,21 @@ type GetRequiredImplementation<Obj extends object, RequiredKeys extends object =
  * type UserRequired = GetRequired<User>
  */
 export type GetRequired<Obj extends object> = GetRequiredImplementation<Obj>
+
+/**
+ * Get only the keys of an object that are optional in the object type otherwise
+ * remove them from the object type
+ *
+ * @example
+ * interface User {
+ *   name: string
+ *   age?: number
+ *   address?: string
+ * }
+ *
+ * // Expected: { age?: number, address?: string }
+ * type UserOptional = GetOptional<User>
+ */
+export type GetOptional<T extends object> = {
+    [Key in keyof T as T[Key] extends Required<T>[Key] ? never : Key]: T[Key]
+}

--- a/test/object-types.test.ts
+++ b/test/object-types.test.ts
@@ -391,3 +391,13 @@ describe("GetRequired", () => {
         expectTypeOf<utilities.GetRequired<{ foo: undefined; bar?: number }>>().toEqualTypeOf<{ foo: undefined }>()
     })
 })
+
+describe("GetOptional", () => {
+    test("Get the optional properties of an object", () => {
+        expectTypeOf<utilities.GetOptional<{ foo: string; bar?: number }>>().toEqualTypeOf<{ bar?: number }>()
+        expectTypeOf<utilities.GetOptional<{ foo: string; bar: number }>>().toEqualTypeOf<{}>()
+        expectTypeOf<utilities.GetOptional<{ foo: null; bar: number }>>().toEqualTypeOf<{}>()
+        expectTypeOf<utilities.GetOptional<{ foo: undefined; bar: number }>>().toEqualTypeOf<{}>()
+        expectTypeOf<utilities.GetOptional<{ foo: undefined; bar?: number }>>().toEqualTypeOf<{ bar?: number }>()
+    })
+})


### PR DESCRIPTION
## Description

This pull request introduces a new utility type called `GetOptional` which retrieves the optional keys of an object type and removes all other keys.

## Checklist
- [ ]  Added documentation.
- [ ]  The changes do not generate any warnings.
- [ ]  I have performed a self-review of my own code
- [ ]  All tests have been added and pass successfully

## Notes
<!-- Add any additional relevant information here -->