### PR TITLE
feat: add `isFalsy` validate type

### DIFF
--- a/src/validate-types.ts
+++ b/src/validate-types.ts
@@ -72,3 +72,12 @@ export const isArray = (value: unknown): value is unknown[] => Array.isArray(val
  * @returns {boolean} true if the value passed is a function
  */
 export const isFunction = (value: unknown): value is Function => typeof value === "function"
+
+/**
+ * Check if the value is falsy (null, undefined, false, 0, -0, or "")
+ * @param value The value to check
+ * @returns {boolean} turns true if the value is falsy
+ */
+export const isFalsy = (value: unknown): boolean => {
+    return isNullish(value) || value === false || value === "" || value === 0
+}

--- a/test/validate-types.test.ts
+++ b/test/validate-types.test.ts
@@ -8,6 +8,7 @@ import {
     isObject,
     isArray,
     isFunction,
+    isFalsy,
 } from "./../src/validate-types"
 
 describe("Primitive Validation", () => {
@@ -116,6 +117,8 @@ describe("Types validation", () => {
             expect(isArray("str")).toBeFalsy()
             expect(isArray(null)).toBeFalsy()
             expect(isArray(undefined)).toBeFalsy()
+            expect(isArray({ foo: "bar", bar: "foobar" })).toBeFalsy()
+            expect(isArray(() => {})).toBeFalsy()
         })
     })
 
@@ -130,6 +133,25 @@ describe("Types validation", () => {
             expect(isFunction("str")).toBeFalsy()
             expect(isFunction(null)).toBeFalsy()
             expect(isFunction(undefined)).toBeFalsy()
+        })
+    })
+
+    describe("isFalsy", () => {
+        test("should return true for falsy values", () => {
+            expect(isFalsy(null)).toBeTruthy()
+            expect(isFalsy(undefined)).toBeTruthy()
+            expect(isFalsy(false)).toBeTruthy()
+            expect(isFalsy(0)).toBeTruthy()
+            expect(isFalsy(-0)).toBeTruthy()
+            expect(isFalsy("")).toBeTruthy()
+        })
+
+        test("should return false for non-falsy values", () => {
+            expect(isFalsy(1)).toBeFalsy()
+            expect(isFalsy(true)).toBeFalsy()
+            expect(isFalsy("str")).toBeFalsy()
+            expect(isFalsy({})).toBeFalsy()
+            expect(isFalsy(() => {})).toBeFalsy()
         })
     })
 })


### PR DESCRIPTION
## Description
This pull request introduces a new validation type called `isFalsy`, which checks if the provided value is equal to `null`, `undefined`, `0`, `false`, or an empty string.


## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
