### PR TITLE
feat: add `Get` utility type

### DIFF
--- a/src/object-types.ts
+++ b/src/object-types.ts
@@ -513,3 +513,30 @@ export type GetRequired<Obj extends object> = GetRequiredImplementation<Obj>
 export type GetOptional<T extends object> = {
     [Key in keyof T as T[Key] extends Required<T>[Key] ? never : Key]: T[Key]
 }
+
+/**
+ * Get the value of a key from an object without worrying about the nested properties
+ * of the object only should separate the keys with a dot.
+ *
+ * @example
+ * interface User {
+ *   foo: {
+ *     bar: {
+ *       foobar: "Hello"
+ *     },
+ *     barfoo: "World"
+ *   },
+ *   age: number
+ * }
+ *
+ * // Expected: "Hello"
+ * type FooBar = GetValue<User, "foo.bar.foobar">
+ *
+ * // Expected: "World"
+ * type FooBar = GetValue<User, "foo.barfoo">
+ */
+export type Get<T, K extends string> = K extends keyof T
+    ? T[K]
+    : K extends `${infer Char extends keyof T & string}.${infer Substr}`
+      ? Get<T[Char], Substr>
+      : never

--- a/test/object-types.test.ts
+++ b/test/object-types.test.ts
@@ -372,3 +372,16 @@ describe("GetOptional", () => {
         expectTypeOf<utilities.GetOptional<{ foo: undefined; bar?: number }>>().toEqualTypeOf<{ bar?: number }>()
     })
 })
+
+describe("Get", () => {
+    test("Get the value of a nested property", () => {
+        expectTypeOf<utilities.Get<{ foo: string }, "foo">>().toEqualTypeOf<string>()
+        expectTypeOf<utilities.Get<{ foo: string; bar: number }, "foo">>().toEqualTypeOf<string>()
+        expectTypeOf<utilities.Get<{ foo: { bar: number } }, "foo.bar">>().toEqualTypeOf<number>()
+        expectTypeOf<utilities.Get<{ foo: { bar: { foobar: boolean } } }, "foo.bar">>().toEqualTypeOf<{ foobar: boolean }>()
+        expectTypeOf<utilities.Get<{ foo: { bar: { foobar: boolean } } }, "foo.bar.foobar">>().toEqualTypeOf<boolean>()
+        expectTypeOf<
+            utilities.Get<{ foo: { bar: { foobar: { barfoo: number } } } }, "foo.bar.foobar.barfoo">
+        >().toEqualTypeOf<number>()
+    })
+})


### PR DESCRIPTION
## Description

This pull request introduces a new utility type called `GetValue` which allows extracting the value of a nested object without worrying about the depth of the object. The user only needs to specify the level of the property using dot notation, as shown in the example below:

```ts
interface User {
  foo: {
    bar: {
      foobar: "Hello"
    },
    barfoo: "World"
  },
  age: number
}

// Expected: "Hello"
type FooBar = GetValue<User, "foo.bar.foobar">
```

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
