### PR TITLE
feat: add `Take` utility type

### DIFF
--- a/src/array-types.ts
+++ b/src/array-types.ts
@@ -1,4 +1,6 @@
 import type { Equals } from "./test.js"
+import { IsNegative } from "./type-guards.js"
+import { Absolute } from "./utils.js"
 
 /**
  * Creates a union type from the literal values of a constant string or number array.
@@ -380,3 +382,34 @@ export type ReturnTypeOf<T> = T extends string
           : T extends Function
             ? Function
             : never
+
+/**
+ * @internal
+ */
+type TakeImplementation<
+    N extends number,
+    Array extends unknown[],
+    Negative = IsNegative<N>,
+    Build extends unknown[] = [],
+> = `${N}` extends `${Build["length"]}` | `-${Build["length"]}`
+    ? Build
+    : Negative extends true
+      ? Array extends [...infer Spread, infer Item]
+          ? TakeImplementation<N, Spread, Negative, [Item, ...Build]>
+          : Build
+      : Array extends [infer Item, ...infer Spread]
+        ? TakeImplementation<N, Spread, Negative, [...Build, Item]>
+        : Build
+
+/**
+ * Extracts the first `N` elements from an array. If `N` is negative,
+ * it extracts the last `N` elements.
+ *
+ * @example
+ * // Expected: [1, 2]
+ * type Take1 = Take<2, [1, 2, 3, 4]>;
+ *
+ * // Expected: [3, 4]
+ * type Take2 = Take<-2, [1, 2, 3, 4]>;
+ */
+export type Take<N extends number, Array extends unknown[]> = TakeImplementation<N, Array>

--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -35,3 +35,15 @@ export type IsOdd<T extends number> = `${T}` extends `${string}${Odd}` ? true : 
  * type CheckOdd = IsEven<2023>;
  */
 export type IsEven<T extends number> = `${T}` extends `${string}${Even}` ? false : true
+
+/**
+ * Check if the number provided is negative or not
+ *
+ * @example
+ * // Expected: true
+ * type CheckNegative = IsNegative<-2024>;
+ *
+ * // Expected: false
+ * type CheckPositive = IsNegative<2024>;
+ */
+export type IsNegative<T extends number> = `${T}` extends `-${number}` ? true : false

--- a/test/array-types.test.ts
+++ b/test/array-types.test.ts
@@ -187,3 +187,19 @@ describe("Includes", () => {
         expectTypeOf<utilities.Includes<[true, false, true], number>>().toEqualTypeOf<false>()
     })
 })
+
+describe("Take", () => {
+    test("Take the first n elements of a tuple", () => {
+        expectTypeOf<utilities.Take<0, [1, 2, 3, 4, 5]>>().toEqualTypeOf<[]>()
+        expectTypeOf<utilities.Take<1, [1, 2, 3, 4, 5]>>().toEqualTypeOf<[1]>()
+        expectTypeOf<utilities.Take<2, [1, 2, 3, 4, 5]>>().toEqualTypeOf<[1, 2]>()
+        expectTypeOf<utilities.Take<3, [1, 2, 3, 4, 5]>>().toEqualTypeOf<[1, 2, 3]>()
+        expectTypeOf<utilities.Take<4, [1, 2, 3, 4, 5]>>().toEqualTypeOf<[1, 2, 3, 4]>()
+        expectTypeOf<utilities.Take<5, [1, 2, 3, 4, 5]>>().toEqualTypeOf<[1, 2, 3, 4, 5]>()
+        expectTypeOf<utilities.Take<5, [1, 2]>>().toEqualTypeOf<[1, 2]>()
+        expectTypeOf<utilities.Take<-1, [1, 2, 3, 4, 5]>>().toEqualTypeOf<[5]>()
+        expectTypeOf<utilities.Take<-2, [1, 2, 3, 4, 5]>>().toEqualTypeOf<[4, 5]>()
+        expectTypeOf<utilities.Take<-3, [1, 2, 3, 4, 5]>>().toEqualTypeOf<[3, 4, 5]>()
+        expectTypeOf<utilities.Take<-4, [1, 2, 3, 4, 5]>>().toEqualTypeOf<[2, 3, 4, 5]>()
+    })
+})


### PR DESCRIPTION
## Description

This pull request introduces a new utility type called `Take`, which allows extracting the first N values of a tuple. If the N value is negative, it takes the N latest values of the tuple.

### Key Features

- Extract the first N values of a tuple using the `Take` utility type.
- Handle negative N values to take the N latest values from the tuple.

This utility type enhances the flexibility and functionality of the package by providing a powerful tool for tuple manipulation.


## Checklist

- [ ] Added documentation.
- [ ] The changes do not generate any warnings.
- [ ] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
