### PR TITLE
feat: add `AnyOf` utility type

### DIFF
--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -72,3 +72,26 @@ export type IsPositive<T extends number> = Not<IsNegative<T>>
  * type CheckStr = IsAny<string>;
  */
 export type IsAny<T> = Equals<T, any>
+
+/**
+ * @internal
+ */
+type False = "" | false | [] | null | undefined | 0 | { [P: string]: never }
+
+/**
+ * Checks if any value in the tuple is true
+ *
+ * @example
+ * // Expected: true
+ * type Test1 = AnyOf<[0, "", false, [], {}, undefined, null, true]>
+ *
+ * // Expected: false
+ * type Test2 = AnyOf<[0, "", false, [], {}, undefined, null]>
+ */
+export type AnyOf<T extends readonly any[]> = T extends [infer Item, ...infer Spread]
+    ? Item extends False
+        ? AnyOf<Spread>
+        : true
+    : false
+
+type Nose = AnyOf<[0, "", false, [], {}, undefined, null]>

--- a/test/type-guards.test.ts
+++ b/test/type-guards.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expectTypeOf } from "vitest"
-import type { IsNegative, IsNever, IsOdd, IsPositive, IsAny, IsEven } from "../src/type-guards"
+import type { IsNegative, IsNever, IsOdd, IsPositive, IsAny, IsEven, AnyOf } from "../src/type-guards"
 
 describe("Utility types for type guards", () => {
     describe("IsNever", () => {
@@ -68,6 +68,19 @@ describe("Utility types for type guards", () => {
             expectTypeOf<IsAny<bigint>>().toEqualTypeOf<false>()
             expectTypeOf<IsAny<symbol>>().toEqualTypeOf<false>()
             expectTypeOf<IsAny<Function>>().toEqualTypeOf<false>()
+        })
+    })
+
+    describe("AnyOf", () => {
+        test("Check if a type is true of the provided types", () => {
+            expectTypeOf<AnyOf<[true, false]>>().toEqualTypeOf<true>()
+            expectTypeOf<AnyOf<[true, true]>>().toEqualTypeOf<true>()
+            expectTypeOf<AnyOf<[false, false]>>().toEqualTypeOf<false>()
+            expectTypeOf<AnyOf<[false, true]>>().toEqualTypeOf<true>()
+            expectTypeOf<AnyOf<[false, false, false, false, false, false, true]>>().toEqualTypeOf<true>()
+            expectTypeOf<AnyOf<[false, false, false, false, false, false, false]>>().toEqualTypeOf<false>()
+            expectTypeOf<AnyOf<[0, "", false, [], {}, undefined, null]>>().toEqualTypeOf<false>()
+            expectTypeOf<AnyOf<[0, "", false, [], {}, undefined, null, true]>>().toEqualTypeOf<true>()
         })
     })
 })


### PR DESCRIPTION
## Description


This pull request introduces a new utility type called `AnyOf`, which allows determining if any value in the provided tuple has a truthy value, such as `true` or `1`.

### Key Features

- **AnyOf Utility Type**: Determine if a tuple contains any truthy values (e.g., `true` or `1`).

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
