### PR TITLE
feat(type): add `DeepPick` utility type

### DIFF
--- a/src/object-types.ts
+++ b/src/object-types.ts
@@ -540,3 +540,33 @@ export type Get<T, K extends string> = K extends keyof T
     : K extends `${infer Char extends keyof T & string}.${infer Substr}`
       ? Get<T[Char], Substr>
       : never
+
+/**
+ * @internal
+ */
+type InternalDeepPick<Obj, Pattern> = Pattern extends `${infer Left}.${infer Right}`
+    ? Left extends keyof Obj
+        ? InternalDeepPick<Obj[Left], Right>
+        : unknown
+    : Pattern extends keyof Obj
+      ? Obj[Pattern]
+      : unknown
+
+/**
+ * Picks the properties of an object at any depth based on the provided pattern.
+ * 
+ * @example
+ * interface User {
+ *   name: string,
+ *   address: {
+ *     street: string,
+ *     avenue: string
+ *   }
+ * }
+ * 
+ * // Expected: { address: { street: string } }
+ * type UserPick = DeepPick<User, "address.street">
+ */
+export type DeepPick<Obj extends object, Patterns extends string> = {
+    [Pattern in Patterns]: InternalDeepPick<Obj, Pattern>
+}

--- a/src/object-types.ts
+++ b/src/object-types.ts
@@ -542,19 +542,8 @@ export type Get<T, K extends string> = K extends keyof T
       : never
 
 /**
- * @internal
- */
-type InternalDeepPick<Obj, Pattern> = Pattern extends `${infer Left}.${infer Right}`
-    ? Left extends keyof Obj
-        ? InternalDeepPick<Obj[Left], Right>
-        : unknown
-    : Pattern extends keyof Obj
-      ? Obj[Pattern]
-      : unknown
-
-/**
  * Picks the properties of an object at any depth based on the provided pattern.
- * 
+ *
  * @example
  * interface User {
  *   name: string,
@@ -563,10 +552,14 @@ type InternalDeepPick<Obj, Pattern> = Pattern extends `${infer Left}.${infer Rig
  *     avenue: string
  *   }
  * }
- * 
+ *
  * // Expected: { address: { street: string } }
  * type UserPick = DeepPick<User, "address.street">
  */
-export type DeepPick<Obj extends object, Patterns extends string> = {
-    [Pattern in Patterns]: InternalDeepPick<Obj, Pattern>
-}
+export type DeepPick<Obj, Pattern> = Pattern extends `${infer Left}.${infer Right}`
+    ? Left extends keyof Obj
+        ? DeepPick<Obj[Left], Right>
+        : unknown
+    : Pattern extends keyof Obj
+      ? Obj[Pattern]
+      : unknown

--- a/test/object-types.test.ts
+++ b/test/object-types.test.ts
@@ -385,3 +385,42 @@ describe("Get", () => {
         >().toEqualTypeOf<number>()
     })
 })
+
+describe("DeepPick", () => {
+    test("Pick properties from nested objects", () => {
+        type Obj = {
+            foo: string
+            bar: number
+            foobar: {
+                foofoo: number
+                barbar: boolean
+                fo: {
+                    bar: string
+                    foobar: number
+                    barfoo: {
+                        foobar: string
+                        bar: number
+                    }
+                }
+            }
+        }
+
+        expectTypeOf<utilities.DeepPick<Obj, "foo">>().toEqualTypeOf<{ foo: string }>()
+        expectTypeOf<utilities.DeepPick<Obj, "bar">>().toEqualTypeOf<{ bar: number }>()
+        expectTypeOf<utilities.DeepPick<Obj, "foobar">>().toEqualTypeOf<{
+            foobar: {
+                foofoo: number
+                barbar: boolean
+                fo: {
+                    bar: string
+                    foobar: number
+                    barfoo: {
+                        foobar: string
+                        bar: number
+                    }
+                }
+            }
+        }>()
+        expectTypeOf<utilities.DeepPick<Obj, "foobar.barbar">>().toEqualTypeOf<{ foobar: { barbar: boolean } }>()
+    })
+})

--- a/test/object-types.test.ts
+++ b/test/object-types.test.ts
@@ -394,7 +394,7 @@ describe("DeepPick", () => {
             foobar: {
                 foofoo: number
                 barbar: boolean
-                fo: {
+                foo: {
                     bar: string
                     foobar: number
                     barfoo: {
@@ -405,22 +405,24 @@ describe("DeepPick", () => {
             }
         }
 
-        expectTypeOf<utilities.DeepPick<Obj, "foo">>().toEqualTypeOf<{ foo: string }>()
-        expectTypeOf<utilities.DeepPick<Obj, "bar">>().toEqualTypeOf<{ bar: number }>()
+        expectTypeOf<utilities.DeepPick<Obj, "foo">>().toEqualTypeOf<string>()
+        expectTypeOf<utilities.DeepPick<Obj, "bar">>().toEqualTypeOf<number>()
         expectTypeOf<utilities.DeepPick<Obj, "foobar">>().toEqualTypeOf<{
-            foobar: {
-                foofoo: number
-                barbar: boolean
-                fo: {
-                    bar: string
-                    foobar: number
-                    barfoo: {
-                        foobar: string
-                        bar: number
-                    }
+            foofoo: number
+            barbar: boolean
+            foo: {
+                bar: string
+                foobar: number
+                barfoo: {
+                    foobar: string
+                    bar: number
                 }
             }
         }>()
-        expectTypeOf<utilities.DeepPick<Obj, "foobar.barbar">>().toEqualTypeOf<{ foobar: { barbar: boolean } }>()
+        expectTypeOf<utilities.DeepPick<Obj, "foobar.barbar">>().toEqualTypeOf<boolean>()
+        expectTypeOf<utilities.DeepPick<Obj, "foobar.foo.barfoo">>().toEqualTypeOf<{
+            foobar: string
+            bar: number
+        }>()
     })
 })


### PR DESCRIPTION
## Description

This pull request introduces a new utility type called `DeepPick`. The `DeepPick` type allows for the selection of a nested property's type within an object, regardless of how deeply nested the property is.

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
