### PR TITLE
feat: implement deep versions in utility types

### DIFF
--- a/src/array-types.ts
+++ b/src/array-types.ts
@@ -52,7 +52,7 @@ export type Pop<Array extends unknown[]> = Array extends [...infer Spread, unkno
 /**
  * @internal
  */
-type FilterImplementation<
+type InternalFilter<
     Array extends readonly unknown[],
     Predicate,
     Build extends unknown[] = [],
@@ -60,8 +60,8 @@ type FilterImplementation<
     Comparator = ToUnion<Predicate>,
 > = Array extends [infer Item, ...infer Spread]
     ? Includes extends true
-        ? FilterImplementation<Spread, Predicate, Item extends Comparator ? [...Build, Item] : Build, Includes>
-        : FilterImplementation<Spread, Predicate, Item extends Comparator ? Build : [...Build, Item], Includes>
+        ? InternalFilter<Spread, Predicate, Item extends Comparator ? [...Build, Item] : Build, Includes>
+        : InternalFilter<Spread, Predicate, Item extends Comparator ? Build : [...Build, Item], Includes>
     : Build
 
 /**
@@ -84,7 +84,7 @@ type FilterImplementation<
  * // Expected: [1]
  * type FilterOut2 = Filter<[0, 1, 2], 0 | 2, false>
  */
-export type Filter<Array extends unknown[], Predicate, Includes extends boolean = true> = FilterImplementation<
+export type Filter<Array extends unknown[], Predicate, Includes extends boolean = true> = InternalFilter<
     Array,
     Predicate,
     [],
@@ -111,13 +111,10 @@ export type Reverse<Array extends unknown[]> = Array extends [infer Item, ...inf
 /**
  * @internal
  */
-type IndexOfImplementation<Array extends unknown[], Match, Index extends unknown[] = []> = Array extends [
-    infer Item,
-    ...infer Spread,
-]
+type InternalIndexOf<Array extends unknown[], Match, Index extends unknown[] = []> = Array extends [infer Item, ...infer Spread]
     ? Equals<Item, Match> extends true
         ? Index["length"]
-        : IndexOfImplementation<Spread, Match, [...Index, Item]>
+        : InternalIndexOf<Spread, Match, [...Index, Item]>
     : -1
 
 /**
@@ -139,18 +136,18 @@ type IndexOfImplementation<Array extends unknown[], Match, Index extends unknown
  * // Expected: 1
  * type IndexOf4 = IndexOf<[string, "a"], "a">;
  */
-export type IndexOf<Array extends unknown[], Match> = IndexOfImplementation<Array, Match, []>
+export type IndexOf<Array extends unknown[], Match> = InternalIndexOf<Array, Match, []>
 
 /**
  * @internal
  */
-type LastIndexOfImplementation<
+type InternalLastIndexOf<
     Array extends unknown[],
     Match,
     Index extends unknown[] = [],
     IndexOf extends unknown[] = [],
 > = Array extends [infer Item, ...infer Spread]
-    ? LastIndexOfImplementation<
+    ? InternalLastIndexOf<
           Spread,
           Match,
           [...Index, Item],
@@ -179,18 +176,18 @@ type LastIndexOfImplementation<
  * // Expected: 5
  * type LastIndexOf4 = LastIndexOf<[string, any, 1, number, "a", any, 1], any>;
  */
-export type LastIndexOf<Array extends unknown[], Match> = LastIndexOfImplementation<Array, Match, [], []>
+export type LastIndexOf<Array extends unknown[], Match> = InternalLastIndexOf<Array, Match, [], []>
 
 /**
  * Helper type to create a tuple with a specific length, repeating a given value
  * Avoids the `Type instantiation is excessively deep and possibly infinite` error
  * @interface
  */
-type RepeatConstructTuple<
+type InternalConstructTuple<
     Length extends number,
     Value extends unknown = unknown,
     Array extends unknown[] = [],
-> = Array["length"] extends Length ? Array : RepeatConstructTuple<Length, Value, [...Array, Value]>
+> = Array["length"] extends Length ? Array : InternalConstructTuple<Length, Value, [...Array, Value]>
 
 /**
  * reate a tuple with a defined size, where each element is of a specified type
@@ -205,7 +202,7 @@ type RepeatConstructTuple<
  * // Expected: ["", ""]
  * type TupleSize3 = ConstructTuple<2, "">;
  */
-export type ConstructTuple<Length extends number, Value extends unknown = unknown> = RepeatConstructTuple<Length, Value, []>
+export type ConstructTuple<Length extends number, Value extends unknown = unknown> = InternalConstructTuple<Length, Value, []>
 
 /**
  * Check if there are duplidated elements inside the tuple
@@ -241,15 +238,15 @@ export type AllEquals<Array extends unknown[], Comparator> = Array extends [infe
 /**
  * @internal
  */
-type ChunkImplementation<
+type InternalChunk<
     Array extends unknown[],
     Length extends number,
     Build extends unknown[] = [],
     Partition extends unknown[] = [],
 > = Array extends [infer Item, ...infer Spread]
     ? [...Partition, Item]["length"] extends Length
-        ? ChunkImplementation<Spread, Length, [...Build, [...Partition, Item]], []>
-        : ChunkImplementation<Spread, Length, Build, [...Partition, Item]>
+        ? InternalChunk<Spread, Length, [...Build, [...Partition, Item]], []>
+        : InternalChunk<Spread, Length, Build, [...Partition, Item]>
     : Size<Partition> extends 0
       ? Build
       : [...Build, Partition]
@@ -267,14 +264,14 @@ type ChunkImplementation<
  * // Expected: [[1, 2, 3], [4, 5]]
  * type Chunk2 = Chunk<[1, 2, 3, 4, 5], 3>;
  */
-export type Chunk<Array extends unknown[], Length extends number> = ChunkImplementation<Array, Length, [], []>
+export type Chunk<Array extends unknown[], Length extends number> = InternalChunk<Array, Length, [], []>
 
 /**
  * @internal
  */
-type ZipImplementation<T, U, Build extends unknown[] = []> = T extends [infer ItemT, ...infer SpreadT]
+type InteralZip<T, U, Build extends unknown[] = []> = T extends [infer ItemT, ...infer SpreadT]
     ? U extends [infer ItemU, ...infer SpreadU]
-        ? ZipImplementation<SpreadT, SpreadU, [...Build, [ItemT, ItemU]]>
+        ? InteralZip<SpreadT, SpreadU, [...Build, [ItemT, ItemU]]>
         : Build
     : Build
 
@@ -290,7 +287,7 @@ type ZipImplementation<T, U, Build extends unknown[] = []> = T extends [infer It
  * // Expected: [[1, "a"], [2, "b"]]
  * type Zip2 = Zip<[1, 2, 3], ["a", "b"]>;
  */
-export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = ZipImplementation<Array1, Array2>
+export type Zip<Array1 extends unknown[], Array2 extends unknown[]> = InteralZip<Array1, Array2>
 
 /**
  * Returns the flatten type of an array.
@@ -332,13 +329,13 @@ export type CompareArrayLength<T extends any[], U extends any[]> = T extends [an
 /**
  * @internal
  */
-type UniqueImplementation<Array extends unknown[], Uniques extends unknown = never, Set extends unknown[] = []> = Array extends [
+type InternalUniques<Array extends unknown[], Uniques extends unknown = never, Set extends unknown[] = []> = Array extends [
     infer Item,
     ...infer Spread,
 ]
     ? Includes<Set, Item> extends true
-        ? UniqueImplementation<Spread, Uniques, Set>
-        : UniqueImplementation<Spread, Uniques | Item, [...Set, Item]>
+        ? InternalUniques<Spread, Uniques, Set>
+        : InternalUniques<Spread, Uniques | Item, [...Set, Item]>
     : Set
 
 /**
@@ -352,7 +349,7 @@ type UniqueImplementation<Array extends unknown[], Uniques extends unknown = nev
  * // Expected: ["a", "b", "c"]
  * type Uniques2 = Unique<["a", "b", "c", "a", "b"]>;
  */
-export type Uniques<Array extends unknown[]> = UniqueImplementation<Array>
+export type Uniques<Array extends unknown[]> = InternalUniques<Array>
 
 /**
  * Create an union type based in the literal values of the tuple provided.
@@ -418,7 +415,7 @@ export type ReturnTypeOf<T> = T extends string
 /**
  * @internal
  */
-type TakeImplementation<
+type InternalTake<
     N extends number,
     Array extends unknown[],
     Negative = IsNegative<N>,
@@ -427,10 +424,10 @@ type TakeImplementation<
     ? Build
     : Negative extends true
       ? Array extends [...infer Spread, infer Item]
-          ? TakeImplementation<N, Spread, Negative, [Item, ...Build]>
+          ? InternalTake<N, Spread, Negative, [Item, ...Build]>
           : Build
       : Array extends [infer Item, ...infer Spread]
-        ? TakeImplementation<N, Spread, Negative, [...Build, Item]>
+        ? InternalTake<N, Spread, Negative, [...Build, Item]>
         : Build
 
 /**
@@ -446,4 +443,4 @@ type TakeImplementation<
  * // Expected: [3, 4]
  * type Take2 = Take<-2, [1, 2, 3, 4]>;
  */
-export type Take<N extends number, Array extends unknown[]> = TakeImplementation<N, Array>
+export type Take<N extends number, Array extends unknown[]> = InternalTake<N, Array>

--- a/src/object-types.ts
+++ b/src/object-types.ts
@@ -88,7 +88,7 @@ export type Awaited<T extends PromiseLike<unknown>> =
  *
  * @param {object} Obj1 - The first object to get the keys from
  * @param {object} Obj2 - The second object to get the keys from
- * @param {boolean} Extends - If `true`, it returns the intersection of the keys (defaults to `false`)
+ * @param {Common} Common - If `true`, returns the common keys between the two objects
  * @example
  * interface Foo {
  *   foo: string,
@@ -101,13 +101,43 @@ export type Awaited<T extends PromiseLike<unknown>> =
  * // Expected: "foo" | "bar"
  * type PropsFooBar = Properties<Foo, Bar>;
  */
-export type Properties<Obj1 extends object, Obj2 extends object, Extends extends boolean = false> = Extends extends true
+export type Properties<Obj1 extends object, Obj2 extends object, Common extends boolean = false> = Common extends true
     ? keyof Obj1 & keyof Obj2
     : keyof Obj1 | keyof Obj2
 
 /**
- * Creates a new object by merging two objects. Properties from `Obj1` override properties
- * from `Obj2` if they have the same key
+ * Checks if a key exists in either of the two objects and returns its value.
+ * If the key does not exist in either object, it returns `never`.
+ *
+ * @param {object} Obj1 - The first object to check
+ * @param {object} Obj2 - The second object to check
+ * @param {string} Key - The key to check
+ * @example
+ * interface Foo {
+ *   foo: string
+ * }
+ *
+ * interface Bar {
+ *   bar: number
+ * }
+ *
+ * // Expected: string
+ * type FooValue = RetrieveKeyValue<Foo, Bar, "foo">;
+ *
+ * // Expected: number
+ * type BarValue = RetrieveKeyValue<Foo, Bar, "bar">;
+ */
+export type RetrieveKeyValue<Obj1 extends object, Obj2 extends object, Key> = Key extends keyof Obj1
+    ? Obj1[Key]
+    : Key extends keyof Obj2
+      ? Obj2[Key]
+      : never
+
+/**
+ * Merges two objects into a new object at any depth. Properties from `Obj1` override properties from `Obj2` if they have the same key.
+ * Additionally, it has two optional parameters:
+ *   - `ByUnion` - If `true`, it creates a union type for properties with the same key, ignoring priority.
+ *   - `PriorityObject` - If `true`, it prioritizes the values which are objects over the values of the first object.
  *
  * @param {object} Obj1 - The first object to merge
  * @param {object} Obj2 - The second object to merge
@@ -119,22 +149,94 @@ export type Properties<Obj1 extends object, Obj2 extends object, Extends extends
  *
  * interface AppStore {
  *   path: string,
- *   hooks: ArgsFunction[]
+ *   hooks: ArgsFunction[],
+ *   storePath: {
+ *     path: string
+ *   }
  * };
  *
  * // Expected: { storePaths: string[], path: string, hooks: ArgsFunction[] }
  * type MergeConfig = Merge<Config, AppStore>;
+ *
+ * // Expected: { storePaths: string[], path: string, hooks: ArgsFunction[], storePath: { path: string } }
+ * type MergeConfigWithPriority = Merge<Config, AppStore, false, true>;
+ *
+ * // Expected: { storePaths: string[], path: string, hooks: ArgsFunction[] | unknown[], storePath: { path: string } }
+ * type MergeConfigWithUnion = Merge<Config, AppStore, true>;
  */
-export type Merge<Obj1 extends object, Obj2 extends object> = {
-    [Property in Properties<Obj1, Obj2>]: RetrieveKeyValue<Obj2, Obj1, Property>
+export type Merge<
+    Obj1 extends object,
+    Obj2 extends object,
+    ByUnion extends boolean = false,
+    PriorityObject extends boolean = true,
+> = {
+    [Property in Properties<Obj1, Obj2>]: Property extends keyof Obj1
+        ? Obj1[Property] extends object
+            ? Property extends keyof Obj2
+                ? ByUnion extends true
+                    ? Obj1[Property] | Obj2[Property]
+                    : Obj2[Property] extends object
+                      ? Prettify<Merge<Obj1[Property], Obj2[Property], ByUnion, PriorityObject>>
+                      : Obj1[Property]
+                : Obj1[Property]
+            : Property extends keyof Obj2
+              ? ByUnion extends true
+                  ? Obj1[Property] | Obj2[Property]
+                  : PriorityObject extends true
+                    ? Obj2[Property] extends object
+                        ? Obj2[Property]
+                        : Obj1[Property]
+                    : Obj1[Property]
+              : Obj1[Property]
+        : Property extends keyof Obj2
+          ? Obj2[Property]
+          : never
 }
 
 /**
  * @internal
  */
-type IntersectionImplementation<Obj1 extends object, Obj2 extends object, Keys = Properties<Obj1, Obj2, true>> = {
-    [Property in Properties<Obj1, Obj2> as Discard<Property, Keys>]: RetrieveKeyValue<Obj1, Obj2, Property>
-}
+type InternalMerge<
+    Array extends readonly object[],
+    Obj extends object,
+    ByUnion extends boolean = false,
+    PriorityObject extends boolean = true,
+> = Array extends [infer Item, ...infer Spread]
+    ? InternalMerge<
+          Spread extends object[] ? Spread : never,
+          Merge<Obj, Item extends object ? Item : {}, ByUnion, PriorityObject>
+      >
+    : Obj
+
+/**
+ * Create a new object type based in the tuple of object types, if the properties
+ * are duplicated will create an union type. It is an implementation of `Merge` type.
+ * It is useful when you have a tuple of object types and you want to merge them into a single object type.
+ *
+ * @param {T[]} Array - The tuple of object types to merge
+ * @example
+ * interface Foo {
+ *   foo: string
+ * };
+ *
+ * interface Bar {
+ *   bar: string
+ * };
+ *
+ * interface FooBar {
+ *   bar: number,
+ *   foo: boolean,
+ *   foobar: string
+ * };
+ *
+ * // Expected: { foo: string | boolean, bar: string | number, foobar: string }
+ * type Merge = MergeAll<[Foo, Bar, FooBar], true>;
+ */
+export type MergeAll<
+    Array extends readonly object[],
+    ByUnion extends boolean = false,
+    PriorityObject extends boolean = true,
+> = InternalMerge<Array, {}, ByUnion, PriorityObject>
 
 /**
  * Create a new object based in the difference keys between the objects.
@@ -156,7 +258,7 @@ type IntersectionImplementation<Obj1 extends object, Obj2 extends object, Keys =
  * // Expected: { gender: number }
  * type DiffFoo = Intersection<Foo, Bar>;
  */
-export type Intersection<Obj1 extends object, Obj2 extends object> = IntersectionImplementation<Obj1, Obj2>
+export type Intersection<Obj1 extends object, Obj2 extends object> = Prettify<Omit<Obj1, keyof Obj2> & Omit<Obj2, keyof Obj1>>
 
 /**
  * Create a new object based in the keys that are assignable of type `Type`
@@ -262,34 +364,6 @@ export type PublicOnly<Obj extends object> = {
 }
 
 /**
- * Checks if a key exists in either of the two objects and returns its value.
- * If the key does not exist in either object, it returns `never`.
- *
- * @param {object} Obj1 - The first object to check
- * @param {object} Obj2 - The second object to check
- * @param {string} Key - The key to check
- * @example
- * interface Foo {
- *   foo: string
- * }
- *
- * interface Bar {
- *   bar: number
- * }
- *
- * // Expected: string
- * type FooValue = RetrieveKeyValue<Foo, Bar, "foo">;
- *
- * // Expected: number
- * type BarValue = RetrieveKeyValue<Foo, Bar, "bar">;
- */
-export type RetrieveKeyValue<Obj1 extends object, Obj2 extends object, Key> = Key extends keyof Obj1
-    ? Obj1[Key]
-    : Key extends keyof Obj2
-      ? Obj2[Key]
-      : never
-
-/**
  * Convert to required the keys speficied in the type `Keys`, and the others fields mantein
  * their definition. When `Keys` is not provided, it should make all properties required. By default
  * it makes all properties required.
@@ -309,34 +383,6 @@ export type RetrieveKeyValue<Obj1 extends object, Obj2 extends object, Key> = Ke
 export type RequiredByKeys<Obj extends object, Keys extends keyof Obj = keyof Obj> = Prettify<
     Required<Pick<Obj, Keys>> & Omit<Obj, Keys>
 >
-
-/**
- *
- * Merge the properties of two objects and it the properties are repeated the types create an union
- *
- * @param {object} Obj1 - The first object to merge
- * @param {object} Obj2 - The second object to merge
- * @example
- * interface Foo {
- *   bar: string
- * };
- *
- * interface Bar {
- *   bar: number
- * };
- *
- * // Expected: { bar: string | number }
- * type MergeFooBar = UnionMerge<Foo, Bar>;
- */
-export type UnionMerge<Obj1 extends object, Obj2 extends object> = {
-    [Prop in Properties<Obj1, Obj2>]: Prop extends keyof Obj1
-        ? Prop extends keyof Obj2
-            ? Obj1[Prop] | Obj2[Prop]
-            : Obj1[Prop]
-        : Prop extends keyof Obj2
-          ? Obj2[Prop]
-          : never
-}
 
 /**
  * Converts top-level readonly properties of an object to mutable properties.
@@ -378,41 +424,6 @@ export type Mutable<Obj extends object> = {
 export type DeepMutable<Obj extends object> = {
     -readonly [Property in keyof Obj]: Obj[Property] extends object ? DeepMutable<Obj[Property]> : Obj[Property]
 }
-
-/**
- * @internal
- */
-type MergeAllImplementation<Array extends readonly object[], Merge extends object = {}> = Array extends [
-    infer Item,
-    ...infer Spread,
-]
-    ? MergeAllImplementation<Spread extends object[] ? Spread : never, UnionMerge<Merge, Item extends object ? Item : {}>>
-    : Merge
-
-/**
- * Create a new object type based in the tuple of object types, if the properties
- * are duplicated will create an union type.
- *
- * @param {T[]} Array - The tuple of object types to merge
- * @example
- * interface Foo {
- *   foo: string
- * };
- *
- * interface Bar {
- *   bar: string
- * };
- *
- * interface FooBar {
- *   bar: number,
- *   foo: boolean,
- *   foobar: string
- * };
- *
- * // Expected: { foo: string | boolean, bar: string | number, foobar: string }
- * type Merge = MergeAll<[Foo, Bar, FooBar]>;
- */
-export type MergeAll<Array extends readonly object[]> = MergeAllImplementation<Array, {}>
 
 /**
  * Create a new object type appending a new property with its value

--- a/src/string-mappers.ts
+++ b/src/string-mappers.ts
@@ -52,11 +52,11 @@ export type Capitalize<Str extends string, FirstWord extends boolean = true> = S
 /**
  * @internal
  */
-type JoinImplementation<Array extends unknown[], Separator extends number | string, Str extends string = ""> = Array extends [
+type InternalJoin<Array extends unknown[], Separator extends number | string, Str extends string = ""> = Array extends [
     infer Char,
     ...infer Chars,
 ]
-    ? JoinImplementation<Chars, Separator, `${Str}${Str extends "" ? "" : Separator}${Char & string}`>
+    ? InternalJoin<Chars, Separator, `${Str}${Str extends "" ? "" : Separator}${Char & string}`>
     : Str
 
 /**
@@ -72,7 +72,7 @@ type JoinImplementation<Array extends unknown[], Separator extends number | stri
  * // Expected: "Hello World"
  * type Join2 = Join<["Hello", "World"], " ">
  */
-export type Join<Array extends unknown[], Separator extends number | string> = JoinImplementation<Array, Separator>
+export type Join<Array extends unknown[], Separator extends number | string> = InternalJoin<Array, Separator>
 
 /**
  * Checks if a string type matchs start with a strig `U`
@@ -94,12 +94,12 @@ export type StartsWith<Str extends string, Match extends string> = Str extends `
 /**
  * @internal
  */
-type DropCharImplementation<
+type InternalDropChar<
     Str extends string,
     Match extends string,
     Build extends string = "",
 > = Str extends `${infer Char}${infer Chars}`
-    ? DropCharImplementation<Chars, Match, Char extends Match ? Build : `${Build}${Char}`>
+    ? InternalDropChar<Chars, Match, Char extends Match ? Build : `${Build}${Char}`>
     : Build
 
 /**
@@ -114,7 +114,7 @@ type DropCharImplementation<
  * // Expected: "butterfly!"
  * type Test2 = DropChar<" b u t t e r f l y ! ", " ">
  */
-export type DropChar<Str extends string, Match extends string> = DropCharImplementation<Str, Match>
+export type DropChar<Str extends string, Match extends string> = InternalDropChar<Str, Match>
 
 /**
  * Checks if a string type matchs start with a strig `Match`
@@ -133,8 +133,8 @@ export type EndsWith<Str extends string, Match extends string> = Str extends `${
 /**
  * @internal
  */
-type LengthOfStringImplementation<Str extends string, Length extends unknown[] = []> = Str extends `${infer Char}${infer Chars}`
-    ? LengthOfStringImplementation<Chars, [...Length, Char]>
+type InternalLengthOfString<Str extends string, Length extends unknown[] = []> = Str extends `${infer Char}${infer Chars}`
+    ? InternalLengthOfString<Chars, [...Length, Char]>
     : Length["length"]
 
 /**
@@ -148,19 +148,19 @@ type LengthOfStringImplementation<Str extends string, Length extends unknown[] =
  * // Expected: 6
  * type Length6 = LengthOfString<"foobar">
  */
-export type LengthOfString<Str extends string> = LengthOfStringImplementation<Str>
+export type LengthOfString<Str extends string> = InternalLengthOfString<Str>
 
 /**
  * @internal
  */
-type IndexOfStringImplementation<
+type InternalIndexOfString<
     Str extends string,
     Match extends string,
     Index extends unknown[] = [],
 > = Str extends `${infer Char}${infer Chars}`
     ? Equals<Char, Match> extends true
         ? Index["length"]
-        : IndexOfStringImplementation<Chars, Match, [...Index, 1]>
+        : InternalIndexOfString<Chars, Match, [...Index, 1]>
     : -1
 
 /**
@@ -175,21 +175,21 @@ type IndexOfStringImplementation<
  * // Expected: -1
  * type IndexOfOutBound = IndexOfString<"comparator is a function", "z">
  */
-export type IndexOfString<Str extends string, Match extends string> = IndexOfStringImplementation<Str, Match>
+export type IndexOfString<Str extends string, Match extends string> = InternalIndexOfString<Str, Match>
 
 /**
  * @internal
  */
-type FirstUniqueCharIndexImplementation<
+type InternalFirstUniqueCharIndex<
     Str extends string,
     Index extends unknown[] = [],
     Build extends string = "",
 > = Str extends `${infer Char}${infer Chars}`
     ? IndexOfString<Chars, Char> extends -1
         ? Char extends Build
-            ? FirstUniqueCharIndexImplementation<Chars, [...Index, 1], Char | Build>
+            ? InternalFirstUniqueCharIndex<Chars, [...Index, 1], Char | Build>
             : Index["length"]
-        : FirstUniqueCharIndexImplementation<Chars, [...Index, 1], Char | Build>
+        : InternalFirstUniqueCharIndex<Chars, [...Index, 1], Char | Build>
     : -1
 
 /**
@@ -204,7 +204,7 @@ type FirstUniqueCharIndexImplementation<
  * // Expected: -1
  * type IndexOfOutBound = FirstUniqueCharIndex<"aabbcc">
  */
-export type FirstUniqueCharIndex<Str extends string> = FirstUniqueCharIndexImplementation<Str>
+export type FirstUniqueCharIndex<Str extends string> = InternalFirstUniqueCharIndex<Str>
 
 /**
  * Replaces the first match of the substring `From` in the string `S` with the new value `To`
@@ -228,13 +228,10 @@ export type Replace<S extends string, From extends string, To extends string> = 
 /**
  * @internal
  */
-type CheckRepeatedCharsImplementation<
-    Str extends string,
-    Characters extends string = "",
-> = Str extends `${infer Char}${infer Chars}`
+type InternalCheckRepeatedChars<Str extends string, Characters extends string = ""> = Str extends `${infer Char}${infer Chars}`
     ? Char extends Characters
         ? true
-        : CheckRepeatedCharsImplementation<Chars, Characters | Char>
+        : InternalCheckRepeatedChars<Chars, Characters | Char>
     : false
 
 /**
@@ -248,18 +245,18 @@ type CheckRepeatedCharsImplementation<
  * // Expected: true
  * type Check1 = CheckRepeatedChars<"hello world">
  */
-export type CheckRepeatedChars<Str extends string> = CheckRepeatedCharsImplementation<Str>
+export type CheckRepeatedChars<Str extends string> = InternalCheckRepeatedChars<Str>
 
 /**
  * @internal
  */
-type ParseUrlParamsImplementation<
+type InternalParseUrlParams<
     URLParams extends string,
     Params extends string = never,
 > = URLParams extends `${infer Segment}/${infer Route}`
     ? Segment extends `:${infer WithoutDots}`
-        ? ParseUrlParamsImplementation<Route, Params | WithoutDots>
-        : ParseUrlParamsImplementation<Route, Params>
+        ? InternalParseUrlParams<Route, Params | WithoutDots>
+        : InternalParseUrlParams<Route, Params>
     : URLParams extends `:${infer WithoutDots}`
       ? Params | WithoutDots
       : Params
@@ -275,12 +272,12 @@ type ParseUrlParamsImplementation<
  * // Expected: "id" | "postId"
  * type Test2 = ParseUrlParams<"users/:id/posts/:postId">
  */
-export type ParseUrlParams<URLParams extends string> = ParseUrlParamsImplementation<URLParams>
+export type ParseUrlParams<URLParams extends string> = InternalParseUrlParams<URLParams>
 
 /**
  * @internal
  */
-type FindAllImplementation<
+type InternalFindAll<
     Str extends string,
     Match extends string,
     Index extends unknown[] = [],
@@ -289,8 +286,8 @@ type FindAllImplementation<
     ? Indexes
     : Str extends `${any}${infer Characters}`
       ? Str extends `${Match}${string}`
-          ? FindAllImplementation<Characters, Match, [...Index, 1], [...Indexes, Index["length"]]>
-          : FindAllImplementation<Characters, Match, [...Index, 1], Indexes>
+          ? InternalFindAll<Characters, Match, [...Index, 1], [...Indexes, Index["length"]]>
+          : InternalFindAll<Characters, Match, [...Index, 1], Indexes>
       : Indexes
 
 /**
@@ -305,4 +302,4 @@ type FindAllImplementation<
  * // Expected: [2, 3, 9]
  * type Test2 = FindAll<"hello world", "l">
  */
-export type FindAll<Str extends string, Match extends string> = FindAllImplementation<Str, Match>
+export type FindAll<Str extends string, Match extends string> = InternalFindAll<Str, Match>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,20 +3,20 @@ import type { DropChar } from "./string-mappers.js"
 /**
  * @internals
  */
-type PercentageParserInternal<
+type InternalPercentageParser<
     Percentage extends string,
     Sign extends string = "",
     Num extends string = "",
     Unit extends string = "",
 > = Percentage extends `${infer Char}${infer Chars}`
     ? Char extends "+" | "-"
-        ? PercentageParserInternal<Chars, Char, Num, Unit>
+        ? InternalPercentageParser<Chars, Char, Num, Unit>
         : Char extends "%"
-          ? PercentageParserInternal<Chars, Sign, Num, "%">
+          ? InternalPercentageParser<Chars, Sign, Num, "%">
           : Char extends `${number}`
-            ? PercentageParserInternal<Chars, Sign, `${Num}${Char}`, Unit>
+            ? InternalPercentageParser<Chars, Sign, `${Num}${Char}`, Unit>
             : Char extends "." | ","
-              ? PercentageParserInternal<Char, Sign, `${Num}${Char}`, Unit>
+              ? InternalPercentageParser<Char, Sign, `${Num}${Char}`, Unit>
               : never
     : [Sign, Num, Unit]
 
@@ -34,7 +34,7 @@ type PercentageParserInternal<
  * // Expected: ["+", "89", "%"]
  * type Test2 = PercentageParser<"+89%">;
  */
-export type PercentageParser<Percentage extends string> = PercentageParserInternal<Percentage, "", "", "">
+export type PercentageParser<Percentage extends string> = InternalPercentageParser<Percentage, "", "", "">
 
 /**
  * Returns the absolute version of a number, string or bigint as a string
@@ -74,19 +74,19 @@ export type Trunc<Math extends string | number | bigint> = `${Math}` extends `.$
  *
  * @link `NumberRange`
  */
-type NumberRangeImplementation<
+type InternalNumberRange<
     Low extends number,
     High extends number,
     Range extends unknown = never,
     Index extends unknown[] = [],
     LowRange extends boolean = false,
 > = Index["length"] extends Low
-    ? NumberRangeImplementation<Low, High, Range | Index["length"], [...Index, 1], true>
+    ? InternalNumberRange<Low, High, Range | Index["length"], [...Index, 1], true>
     : Index["length"] extends High
       ? Range | Index["length"]
       : LowRange extends true
-        ? NumberRangeImplementation<Low, High, Range | Index["length"], [...Index, 1], LowRange>
-        : NumberRangeImplementation<Low, High, Range, [...Index, 1], LowRange>
+        ? InternalNumberRange<Low, High, Range | Index["length"], [...Index, 1], LowRange>
+        : InternalNumberRange<Low, High, Range, [...Index, 1], LowRange>
 
 /**
  * Creates a range of numbers that starts from `Low` and ends in `High`. The range is inclusive
@@ -108,4 +108,4 @@ export type NumberRange<Low extends number, High extends number> = `${Low}` exte
       ? never
       : Low extends High
         ? Low
-        : NumberRangeImplementation<Low, High>
+        : InternalNumberRange<Low, High>

--- a/test/object-types.test.ts
+++ b/test/object-types.test.ts
@@ -191,23 +191,23 @@ describe("Mutable", () => {
 describe("DeepMutable", () => {
     test("Converts all properties to non readonly of an object type", () => {
         interface Test5 {
-            foo: [
-                { bar: string },
+            readonly foo: [
+                { readonly bar: string },
                 {
-                    foobar: {
-                        foofoo: number
+                    readonly foobar: {
+                        readonly foofoo: number
                     }
                 },
             ]
         }
 
         interface Test6 {
-            foo: {
-                bar: [
+            readonly foo: {
+                readonly bar: [
                     {
-                        foobar: string
-                        barfoo: {
-                            foofoo: number
+                        readonly foobar: string
+                        readonly barfoo: {
+                            readonly foofoo: number
                         }
                     },
                 ]
@@ -223,8 +223,28 @@ describe("DeepMutable", () => {
         expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<{ foo: [{ bar: string; foobar: number }] }>>>().toEqualTypeOf<{
             foo: [{ bar: string; foobar: number }]
         }>()
-        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test5>>>().toEqualTypeOf<Test5>()
-        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test6>>>().toEqualTypeOf<Test6>()
+        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test5>>>().toEqualTypeOf<{
+            foo: [
+                { bar: string },
+                {
+                    foobar: {
+                        foofoo: number
+                    }
+                },
+            ]
+        }>()
+        expectTypeOf<utilities.DeepMutable<utilities.DeepReadonly<Test6>>>().toEqualTypeOf<{
+            foo: {
+                bar: [
+                    {
+                        foobar: string
+                        barfoo: {
+                            foofoo: number
+                        }
+                    },
+                ]
+            }
+        }>()
     })
 })
 
@@ -375,6 +395,8 @@ describe("Pick Utilities", () => {
             }>()
         })
     })
+
+    type N = utilities.PickByType<{ foo: () => {}; bar: number; foobar: {} }, () => {}>
 })
 
 describe("ReplaceKeys", () => {
@@ -383,13 +405,13 @@ describe("ReplaceKeys", () => {
             foo: string
             bar: string
         }>()
-        expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "foobar", { bar: string }>>().toEqualTypeOf<{
+        expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "foo", { foo: string }>>().toEqualTypeOf<{
             foo: string
             bar: number
         }>()
-        expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "bar", { foobar: string }>>().toEqualTypeOf<{
+        expectTypeOf<utilities.ReplaceKeys<{ foo: string; bar: number }, "bar", { bar: string }>>().toEqualTypeOf<{
             foo: string
-            bar: unknown
+            bar: string
         }>()
         expectTypeOf<
             utilities.ReplaceKeys<{ foo: string; bar: number }, "foo" | "bar", { foo: number; bar: boolean }>
@@ -478,19 +500,6 @@ describe("GetOptional", () => {
     })
 })
 
-describe("Get", () => {
-    test("Get the value of a nested property", () => {
-        expectTypeOf<utilities.Get<{ foo: string }, "foo">>().toEqualTypeOf<string>()
-        expectTypeOf<utilities.Get<{ foo: string; bar: number }, "foo">>().toEqualTypeOf<string>()
-        expectTypeOf<utilities.Get<{ foo: { bar: number } }, "foo.bar">>().toEqualTypeOf<number>()
-        expectTypeOf<utilities.Get<{ foo: { bar: { foobar: boolean } } }, "foo.bar">>().toEqualTypeOf<{ foobar: boolean }>()
-        expectTypeOf<utilities.Get<{ foo: { bar: { foobar: boolean } } }, "foo.bar.foobar">>().toEqualTypeOf<boolean>()
-        expectTypeOf<
-            utilities.Get<{ foo: { bar: { foobar: { barfoo: number } } } }, "foo.bar.foobar.barfoo">
-        >().toEqualTypeOf<number>()
-    })
-})
-
 describe("DeepPick", () => {
     test("Pick properties from nested objects", () => {
         type Obj = {
@@ -510,9 +519,9 @@ describe("DeepPick", () => {
             }
         }
 
-        expectTypeOf<utilities.Get<Obj, "foo">>().toEqualTypeOf<string>()
-        expectTypeOf<utilities.Get<Obj, "bar">>().toEqualTypeOf<number>()
-        expectTypeOf<utilities.Get<Obj, "foobar">>().toEqualTypeOf<{
+        expectTypeOf<utilities.DeepPick<Obj, "foo">>().toEqualTypeOf<string>()
+        expectTypeOf<utilities.DeepPick<Obj, "bar">>().toEqualTypeOf<number>()
+        expectTypeOf<utilities.DeepPick<Obj, "foobar">>().toEqualTypeOf<{
             foofoo: number
             barbar: boolean
             foo: {
@@ -524,10 +533,24 @@ describe("DeepPick", () => {
                 }
             }
         }>()
-        expectTypeOf<utilities.Get<Obj, "foobar.barbar">>().toEqualTypeOf<boolean>()
-        expectTypeOf<utilities.Get<Obj, "foobar.foo.barfoo">>().toEqualTypeOf<{
+        expectTypeOf<utilities.DeepPick<Obj, "foobar.barbar">>().toEqualTypeOf<boolean>()
+        expectTypeOf<utilities.DeepPick<Obj, "foobar.foo.barfoo">>().toEqualTypeOf<{
             foobar: string
             bar: number
         }>()
+    })
+})
+
+describe("PartialByKeys", () => {
+    test("Convert required properties in an object", () => {
+        expectTypeOf<utilities.PartialByKeys<{ foo: string; bar: number }, "foo">>().toEqualTypeOf<{
+            foo?: string
+            bar: number
+        }>()
+        expectTypeOf<utilities.PartialByKeys<{ foo: string; bar: number }, "bar">>().toEqualTypeOf<{
+            foo: string
+            bar?: number
+        }>()
+        expectTypeOf<utilities.PartialByKeys<{ foo: string; bar: number }>>().toEqualTypeOf<{ foo?: string; bar?: number }>()
     })
 })


### PR DESCRIPTION
## Description

This pull request implements deep for utility types which their behavior supports nested operations

### Key Changes
- Updated the `Merge` utility type to support operations at any depth.
- Removed the `UnionMerge` utility type.
- Updated the `MergeAll` utility type for deeper operations.
- Updated the `Intersection` utility type to handle deep versions.
- Updated tests for object types to reflect changes.

## Checklist

- [ ] Added documentation.
- [ ] The changes do not generate any warnings.
- [ ] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
