### PR TITLE
chore(re-release): new versions 0.16.0 and 0.17.0 published on npm

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -8,8 +8,6 @@ on:
   push:
     branches-ignore:
       - master
-    paths:
-      - app/
 
 jobs:
   deploy-preview:

--- a/.github/workflows/production.yaml
+++ b/.github/workflows/production.yaml
@@ -46,6 +46,9 @@ jobs:
           node-version: "18.x"
           registry-url: https://registry.npmjs.org/
 
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
       - run: pnpm install
       - run: pnpm build
       - run: pnpm publish --access public --no-git-checks


### PR DESCRIPTION
## Description

This pull request re-publishes versions `0.16.0` and `0.17.0`. The previous attempt to publish these versions failed due to incorrect `ci.yaml` configuration and insufficient permissions for npm and pnpm.

### Affected Pull Requests
- #141 
- #149 

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
