### PR TITLE
feat(core): add `DeepKeys` utility types

### DIFF
--- a/src/object-types.ts
+++ b/src/object-types.ts
@@ -1,7 +1,7 @@
 import type { Equals } from "./test.js"
 import type { IsNever } from "./type-guards.d.ts"
 import type { ArgsFunction } from "./types.js"
-import type { ReturnTypeOf } from "./array-types.js"
+import type { ReturnTypeOf, TupleToUnion } from "./array-types.js"
 
 /**
  * Utility type that transforms an object to have each property on a new line
@@ -637,3 +637,29 @@ export type DeepPick<Obj, Pattern> = Pattern extends `${infer Left}.${infer Righ
     : Pattern extends keyof Obj
       ? Obj[Pattern]
       : unknown
+
+/**
+ * Returns the keys of an object of any depth of an object
+ *
+ * @param {object} Obj - The object to get the keys from
+ * @example
+ *
+ * interface User {
+ *   name: string,
+ *   address: {
+ *     street: string,
+ *     avenue: string
+ *   }
+ * }
+ *
+ * // Expected: "name" | "address" | "address.street" | "address.avenue"
+ * type UserKeys = DeepKeys<User>
+ */
+export type DeepKeys<Obj extends object> = {
+    [Property in keyof Obj]: Obj[Property] extends object
+        ? // @ts-ignore
+          TupleToUnion<[Property, `${Property & string}.${DeepKeys<Obj[Property]>}`]>
+        : Property extends number
+          ? `${Property & number}`
+          : Property
+}[keyof Obj]

--- a/test/object-types.test.ts
+++ b/test/object-types.test.ts
@@ -555,10 +555,10 @@ describe("PartialByKeys", () => {
     })
 })
 
-describe("DeepPaths", () => {
+describe("DeepKeys", () => {
     test("Get the paths of an object", () => {
         expectTypeOf<
-            utilities.DeepPaths<{
+            utilities.DeepKeys<{
                 foo: string
                 bar: number
                 foobar: {

--- a/test/object-types.test.ts
+++ b/test/object-types.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expectTypeOf } from "vitest"
-import type * as utilities from "../src/object-types"
+import * as utilities from "../src/object-types"
 
 describe("Readonly", () => {
     test("DeepReadonly for objects", () => {
@@ -552,5 +552,50 @@ describe("PartialByKeys", () => {
             bar?: number
         }>()
         expectTypeOf<utilities.PartialByKeys<{ foo: string; bar: number }>>().toEqualTypeOf<{ foo?: string; bar?: number }>()
+    })
+})
+
+describe("DeepPaths", () => {
+    test("Get the paths of an object", () => {
+        expectTypeOf<
+            utilities.DeepPaths<{
+                foo: string
+                bar: number
+                foobar: {
+                    foofoo: number
+                    barbar: boolean
+                    foo: {
+                        bar: string
+                        foobar: number
+                        barfoo: {
+                            foobar: string
+                            bar: number
+                        }
+                        fn: () => {}
+                    }
+                }
+                fn: () => {}
+                123: string
+                "123-foo": string
+                "123-foo-bar": string
+            }>
+        >().toEqualTypeOf<
+            | "foo"
+            | "bar"
+            | "foobar"
+            | "foobar.foofoo"
+            | "foobar.barbar"
+            | "foobar.foo"
+            | "foobar.foo.bar"
+            | "foobar.foo.foobar"
+            | "foobar.foo.barfoo"
+            | "foobar.foo.barfoo.foobar"
+            | "foobar.foo.barfoo.bar"
+            | "foobar.foo.fn"
+            | "fn"
+            | "123"
+            | "123-foo"
+            | "123-foo-bar"
+        >()
     })
 })


### PR DESCRIPTION
## Description

This pull request introduces a new utility type called `DeepKeys`. The `DeepKeys` type returns a union of all the keys present in an object, regardless of the depth at which they occur. When nested properties exist, the keys are concatenated using a dot notation, for example, `user.address`.

**Example Usage:**
```typescript
type User = {
  name: string;
  address: {
    street: string;
    city: string;
  };
};

// Expected: "name" | "address.street" | "address.city"
type Keys = DeepKeys<User>; 
```

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
