### PR TITLE
chore(types): improve types adding autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,14 +47,7 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
-      "import": "./dist/index.d.ts",
-      "require": "./dist/index.d.ts"
-    },
-    "./validate": {
-      "types": "./dist/utils/validate-types.d.ts",
-      "import": "./dist/utils/validate-types.js",
-      "require": "./dist/utils/validate-types.cjs"
+      "types": "./dist/index.d.ts"
     },
     "./arrays": {
       "types": "./dist/array-types.d.ts"
@@ -76,6 +69,11 @@
     },
     "./utilities": {
       "types": "./dist/utility-types.d.ts"
+    },
+    "./validate": {
+      "types": "./dist/utils/validate-types.d.ts",
+      "import": "./dist/utils/validate-types.js",
+      "require": "./dist/utils/validate-types.cjs"
     }
   },
   "files": [

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,7 +36,31 @@ export type Primitive = Omit<PrimitiveNullish, "null" | "undefined">
  * Represents a whitespace character: space, newline, tab, carriage return, form feed,
  * line separator, or paragraph separator.
  */
-export type WhiteSpaces = " " | "\n" | "\t" | "\r" | "\f" | "\u2028" | "\u2029"
+export type WhiteSpaces =
+    | " "
+    | "\n"
+    | "\t"
+    | "\r"
+    | "\f"
+    | "\v"
+    | "\u00A0"
+    | "\u1680"
+    | "\u2000"
+    | "\u2001"
+    | "\u2002"
+    | "\u2003"
+    | "\u2004"
+    | "\u2005"
+    | "\u2006"
+    | "\u2007"
+    | "\u2008"
+    | "\u2009"
+    | "\u200A"
+    | "\u2028"
+    | "\u2029"
+    | "\u202F"
+    | "\u205F"
+    | "\u3000"
 
 /**
  * Represents the empty values

--- a/test/object-types.test.ts
+++ b/test/object-types.test.ts
@@ -151,12 +151,12 @@ describe("PublicOnly", () => {
     })
 })
 
-describe("RetrieveKeyValue", () => {
+describe("Get", () => {
     test("Exist the key within objects", () => {
-        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { bar: number }, "foo">>().toEqualTypeOf<string>()
-        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { bar: number }, "bar">>().toEqualTypeOf<number>()
-        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { foo: number }, "foo">>().toEqualTypeOf<string>()
-        expectTypeOf<utilities.RetrieveKeyValue<{ foo: string }, { foo: number }, "foobar">>().toEqualTypeOf<never>()
+        expectTypeOf<utilities.Get<{ foo: string }, { bar: number }, "foo">>().toEqualTypeOf<string>()
+        expectTypeOf<utilities.Get<{ foo: string }, { bar: number }, "bar">>().toEqualTypeOf<number>()
+        expectTypeOf<utilities.Get<{ foo: string }, { foo: number }, "foo">>().toEqualTypeOf<string>()
+        expectTypeOf<utilities.Get<{ foo: string }, { foo: number }, "foobar">>().toEqualTypeOf<never>()
     })
 })
 
@@ -272,21 +272,21 @@ describe("MergeAll", () => {
     })
 })
 
-describe("AddPropertyToObject", () => {
+describe("Append", () => {
     test("Append a new property of an exist object type", () => {
-        expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", number>>().toEqualTypeOf<{
+        expectTypeOf<utilities.Append<{ foo: string }, "bar", number>>().toEqualTypeOf<{
             foo: string
             bar: number
         }>()
-        expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", { foobar: number; barfoo: boolean }>>().toEqualTypeOf<{
+        expectTypeOf<utilities.Append<{ foo: string }, "bar", { foobar: number; barfoo: boolean }>>().toEqualTypeOf<{
             foo: string
             bar: { foobar: number; barfoo: boolean }
         }>()
-        expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", [1, 2, 3]>>().toEqualTypeOf<{
+        expectTypeOf<utilities.Append<{ foo: string }, "bar", [1, 2, 3]>>().toEqualTypeOf<{
             foo: string
             bar: [1, 2, 3]
         }>()
-        expectTypeOf<utilities.AddPropertyToObject<{ foo: string }, "bar", string | boolean | number>>().toEqualTypeOf<{
+        expectTypeOf<utilities.Append<{ foo: string }, "bar", string | boolean | number>>().toEqualTypeOf<{
             foo: string
             bar: string | boolean | number
         }>()


### PR DESCRIPTION

## Description

This pull request improve some types adding autocomplete in parameters that accept the keys of an object type. This implementation was added thanks to `DeepKeys` utility type which allows to retrive all of the keys of an object type

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
