### PR TITLE
feat(types): add `IsArray` and `IsObject` types

### DIFF
--- a/src/type-guards.ts
+++ b/src/type-guards.ts
@@ -100,3 +100,29 @@ export type AnyOf<T extends readonly any[]> = T extends [infer Item, ...infer Sp
         ? AnyOf<Spread>
         : true
     : false
+
+/**
+ * Checks if all values in the tuple are true
+ *
+ * @param {unknown[]} T - The tuple to check
+ * @example
+ * // Expected: true
+ * type Test1 = IsArray<[1, 2, 3]>
+ *
+ * // Expected: false
+ * type Test2 = IsArray<{ key: string }>
+ */
+export type IsArray<T> = T extends unknown[] ? true : false
+
+/**
+ * Checks if the type provided is an object
+ *
+ * @param T - The type to check
+ * @example
+ * // Expected: true
+ * type Test1 = IsObject<{ key: string }>
+ *
+ * // Expected: false
+ * type Test2 = IsObject<[1, 2, 3]>
+ */
+export type IsObject<T> = T extends object ? Not<IsArray<T>> : false


### PR DESCRIPTION
## Description

This pull request introdues new utility types `IsArray` and `IsObject`, which are useful and powerful types for checking if provided types are arrays or objects. The main reason for introduction of these two types is improve the accuracy of type checking between objects and arrays, addressing issues in multiples scenarios where this validation was failing. 

> [!NOTE]
> These types don't include tests because pull request #158 is working on that aspect. Therefore, it is not necessary to add tests in this pull request.


<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [ ] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
