### PR TITLE
feat(types): add `DeepPartial` and `DeepRequired` types

### DIFF
--- a/src/object-types.ts
+++ b/src/object-types.ts
@@ -681,3 +681,45 @@ export type DeepKeys<Obj extends object> = {
           ? `${Property & number}`
           : Property
 }[keyof Obj]
+
+/**
+ * Create a new object type with all properties being optional at any depth.
+ *
+ * @param {object} Obj - The object to make optional
+ * @example
+ *
+ * interface User {
+ *   name: string,
+ *   address: {
+ *     street: string,
+ *     avenue: string
+ *   }
+ * }
+ *
+ * // Expected: { name?: string, address?: { street?: string, avenue?: string } }
+ * type UserOptional = DeepPartial<User>
+ */
+export type DeepPartial<Obj extends object> = {
+    [Property in keyof Obj]?: Obj[Property] extends object ? Prettify<DeepPartial<Obj[Property]>> : Obj[Property]
+}
+
+/**
+ * Create a new object type with all properties being required at any depth.
+ *
+ * @param {object} Obj - The object to make required
+ * @example
+ *
+ * interface User {
+ *   name?: string,
+ *   address?: {
+ *     street?: string,
+ *     avenue?: string
+ *   }
+ * }
+ *
+ * // Expected: { name: string, address: { street: string, avenue: string } }
+ * type UserRequired = DeepRequired<User>
+ */
+export type DeepRequired<Obj extends object> = {
+    [Property in keyof Obj]-?: Obj[Property] extends object ? Prettify<DeepRequired<Obj[Property]>> : Obj[Property]
+}


### PR DESCRIPTION
## Description

This pull request introduces two new utility types to the `@halvaradop/ts-utility-types` library. These new types work deeply with the object types provided. This addition addresses the issue mentioned in #160.

### Key Changes
- `DeepPartial`: Makes all properties of the provided object type partial.
- `DeepRequired`: Makes all properties of the provided object type required.

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code.
- [x] All tests have been added and pass successfully.

## Notes
