### PR TITLE
chore(ci): add `test` job to `ci.yaml` workflow

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,4 +37,6 @@ jobs:
       - uses: pnpm/action-setup@v4
 
       - name: Install package dependencies
-        run: pnpm test
+        run: pnpm install --frozen-lockfile
+
+      - run: pnpm test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,13 +11,30 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: setup node
+      - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "18.x"
 
       - uses: pnpm/action-setup@v4
+
       - name: Install package dependencies
         run: pnpm install --frozen-lockfile
 
       - run: pnpm build:types
+
+  test:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "18.x"
+
+      - uses: pnpm/action-setup@v4
+
+      - name: Install package dependencies
+        run: pnpm test


### PR DESCRIPTION
## Description

This pull request updates the `ci.yaml` workflow by adding a new job called `test`. This job runs tests to check if the `validate-types` are correct. This update helps enforce a rule in the repository that automatically updates pull requests when the master branch is updated or new changes are merged. This avoids pull requests with old versions and deprecated content.

To be precise, this update only works with the `validate-types.ts` file within the `test` folder, as it is the only content that checks the real values and not an expected type like the utility types.

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code.
- [x] All tests have been added and pass successfully.

## Notes

<!-- Add any additional relevant information here -->
