### PR TITLE
feat: add `DeepNullable` and `DeepNonNullable` types

### DIFF
--- a/src/object-types.ts
+++ b/src/object-types.ts
@@ -814,3 +814,51 @@ export type DeepPick<Obj extends object, Path extends LiteralUnion<DeepKeys<Obj>
             : never
         : Obj[Property]
 }
+
+/**
+ * Append a null value to all properties of an object at any depth.
+ * This is the opposite of `DeepNonNullable`.
+ *
+ * @param {object} Obj - The object to append the null value
+ * @example
+ *
+ * interface User {
+ *   name: string,
+ *   address: {
+ *     street: string,
+ *     avenue: string
+ *   }
+ * }
+ *
+ * // Expected: { name: string | null, address: { street: string | null, avenue: string | null } }
+ * type UserNullable = DeepNullable<User>
+ */
+export type DeepNullable<Obj extends object> = {
+    [Property in keyof Obj]: IsObject<Obj[Property]> extends true
+        ? Prettify<DeepNullable<Obj[Property] & {}>> | null
+        : Obj[Property] | null
+}
+
+/**
+ * Removes the null value from all properties of an object at any depth.
+ * This is the opposite of `DeepNullable`.
+ *
+ * @param {object} Obj - The object to remove the null value
+ * @example
+ *
+ * interface User {
+ *   name: string | null,
+ *   address: {
+ *     street: string | null,
+ *     avenue: string | null
+ *   } | null
+ * }
+ *
+ * // Expected: { name: string, address: { street: string, avenue: string } }
+ * type UserNonNullable = DeepNonNullable<User>
+ */
+export type DeepNonNullable<Obj extends object> = {
+    [Property in keyof Obj]: IsObject<Exclude<Obj[Property], null>> extends true
+        ? Prettify<DeepNonNullable<Exclude<Obj[Property] & {}, null>>>
+        : Exclude<Obj[Property], null>
+}

--- a/test/object-types.test.ts
+++ b/test/object-types.test.ts
@@ -1116,3 +1116,124 @@ describe("DeepPick", () => {
         }>()
     })
 })
+
+describe("DeepNullable", () => {
+    test("Adds null vaalues for all of the properties of an objects", () => {
+        expectTypeOf<utilities.DeepNullable<Case<DeepWithObjectsA>>>().toEqualTypeOf<{
+            foo: string | null
+            bar: number | null
+            foobar: {} | null
+        }>()
+        expectTypeOf<utilities.DeepNullable<DeepWithObjectsA>>().toEqualTypeOf<{
+            foo: string | null
+            bar: number | null
+            foobar: {
+                foo: boolean | null
+                bar: string | null
+                foobar: {
+                    foo: symbol | null
+                    bar: number | null
+                    foobar: {
+                        foo: bigint | null
+                        bar: string | null
+                        foobar: {
+                            bar: number | null
+                        } | null
+                    } | null
+                } | null
+            } | null
+        }>()
+        expectTypeOf<utilities.DeepNullable<Case<DeepWithFunctions>>>().toEqualTypeOf<{
+            fix: (() => number) | null
+            foobar: {} | null
+        }>()
+        expectTypeOf<utilities.DeepNullable<DeepWithFunctions>>().toEqualTypeOf<{
+            fix: (() => number) | null
+            foobar: {
+                fix: (() => string) | null
+                foobar: {
+                    fix: (() => boolean) | null
+                    foobar: {
+                        fix: (() => symbol) | null
+                        foobar: {
+                            fix: (() => bigint) | null
+                        } | null
+                    } | null
+                } | null
+            } | null
+        }>()
+        expectTypeOf<utilities.DeepNullable<Case<DeepWithArray>>>().toEqualTypeOf<{
+            buz: string[] | null
+            foobar: {} | null
+        }>()
+        expectTypeOf<utilities.DeepNullable<DeepWithArray>>().toEqualTypeOf<{
+            buz: string[] | null
+            foobar: {
+                buz: number[] | null
+                foobar: {
+                    buz: boolean[] | null
+                    foobar: {
+                        buz: symbol[] | null
+                        foobar: {
+                            buz: bigint[] | null
+                        } | null
+                    } | null
+                } | null
+            } | null
+        }>()
+    })
+})
+
+describe("DeepNonNullable", () => {
+    test("Removes null values for all of the properties of an objects", () => {
+        expectTypeOf<utilities.DeepNonNullable<utilities.DeepNullable<DeepWithObjectsA>>>().toEqualTypeOf<{
+            foo: string
+            bar: number
+            foobar: {
+                foo: boolean
+                bar: string
+                foobar: {
+                    foo: symbol
+                    bar: number
+                    foobar: {
+                        foo: bigint
+                        bar: string
+                        foobar: {
+                            bar: number
+                        }
+                    }
+                }
+            }
+        }>()
+        expectTypeOf<utilities.DeepNonNullable<utilities.DeepNullable<DeepWithArray>>>().toEqualTypeOf<{
+            buz: string[]
+            foobar: {
+                buz: number[]
+                foobar: {
+                    buz: boolean[]
+                    foobar: {
+                        buz: symbol[]
+                        foobar: {
+                            buz: bigint[]
+                        }
+                    }
+                }
+            }
+        }>()
+        expectTypeOf<utilities.DeepNonNullable<utilities.DeepNullable<DeepWithFunctions>>>().toEqualTypeOf<{
+            fix: () => number
+            foobar: {
+                fix: () => string
+                foobar: {
+                    fix: () => boolean
+                    foobar: {
+                        fix: () => symbol
+                        foobar: {
+                            fix: () => bigint
+                        }
+                    }
+                }
+            }
+        }>()
+    })
+})


### PR DESCRIPTION
## Description

This pull request introduces two new utility types: `DeepNullable` and `DeepNonNullable`. These utility types add and remove null values from all properties at any depth of an object.

This pull request addresses issue #160.

<!-- Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code.
- [x] All tests have been added and pass successfully.

## Notes

<!-- Add any additional relevant information here -->
