### PR TITLE
feat(types): add `DeepNonNullish` and `FilterNonNullish`

### DIFF
--- a/src/array-types.ts
+++ b/src/array-types.ts
@@ -1,5 +1,7 @@
 import type { Equals } from "./test.js"
+import type { Prettify, DeepNonNullish } from "./object-types.js"
 import type { IsArray, IsFunction, IsNegative, IsObject } from "./type-guards.js"
+import type { Nullish } from "./types.js"
 
 /**
  * Creates a union type from the literal values of a constant string or number array.
@@ -448,3 +450,17 @@ type InternalTake<
  * type Take2 = Take<-2, [1, 2, 3, 4]>;
  */
 export type Take<N extends number, Array extends unknown[]> = InternalTake<N, Array>
+
+/**
+ * Removes all nullish values from the provided array. This utility type implements the
+ * `DeepNonNullish` type to ensure that all nested objects are also checked for nullish values.
+ *
+ * @param {unknown[]} Array - The array to filter
+ */
+export type FilterNonNullish<Array extends unknown[]> = Array extends [infer Item, ...infer Spread]
+    ? Item extends Nullish
+        ? FilterNonNullish<Spread>
+        : IsObject<Item> extends true
+          ? [Prettify<DeepNonNullish<Item & {}>>, ...FilterNonNullish<Spread>]
+          : [Item, ...FilterNonNullish<Spread>]
+    : Array

--- a/src/object-types.ts
+++ b/src/object-types.ts
@@ -1,6 +1,7 @@
 import type { Equals } from "./test.js"
 import type { IsNever, IsObject } from "./type-guards.d.ts"
-import type { ReturnTypeOf, TupleToUnion } from "./array-types.js"
+import type { ReturnTypeOf, TupleToUnion, FilterNonNullish } from "./array-types.js"
+import type { Nullish } from "./types.js"
 
 /**
  * Utility type that transforms an object to have each property on a new line
@@ -861,4 +862,30 @@ export type DeepNonNullable<Obj extends object> = {
     [Property in keyof Obj]: IsObject<Exclude<Obj[Property], null>> extends true
         ? Prettify<DeepNonNullable<Exclude<Obj[Property] & {}, null>>>
         : Exclude<Obj[Property], null>
+}
+
+/**
+ * Removes the key-value pairs of an object that are nullish (null or undefined).
+ *
+ * @param {object} Obj - The object to remove the nullish values
+ * @example
+ *
+ * interface User {
+ *   name: string | null,
+ *   address: {
+ *     zip: string
+ *     street: string | null,
+ *     avenue: undefined
+ *   }
+ * }
+ *
+ * // Expected: { address: { zip: string } }
+ * type UserNonNullish = DeepNonNullish<User>
+ */
+export type DeepNonNullish<Obj extends object> = {
+    [Property in keyof Obj as Obj[Property] extends Nullish ? never : Property]: IsObject<Obj[Property]> extends true
+        ? Prettify<DeepNonNullish<Obj[Property] & {}>>
+        : Obj[Property] extends unknown[]
+          ? FilterNonNullish<Obj[Property]>
+          : Obj[Property]
 }

--- a/test/array-types.test.ts
+++ b/test/array-types.test.ts
@@ -203,3 +203,30 @@ describe("Take", () => {
         expectTypeOf<utilities.Take<-4, [1, 2, 3, 4, 5]>>().toEqualTypeOf<[2, 3, 4, 5]>()
     })
 })
+
+describe("FilterNonNullish", () => {
+    test("Filter out nullish values", () => {
+        expectTypeOf<utilities.FilterNonNullish<[1, 2, null, undefined, 3]>>().toEqualTypeOf<[1, 2, 3]>()
+        expectTypeOf<utilities.FilterNonNullish<[null, undefined]>>().toEqualTypeOf<[]>()
+        expectTypeOf<utilities.FilterNonNullish<[1, 2, 3]>>().toEqualTypeOf<[1, 2, 3]>()
+        expectTypeOf<utilities.FilterNonNullish<[null, undefined, "foo", "bar"]>>().toEqualTypeOf<["foo", "bar"]>()
+        expectTypeOf<utilities.FilterNonNullish<[null, undefined, 1, 2, 3]>>().toEqualTypeOf<[1, 2, 3]>()
+        expectTypeOf<utilities.FilterNonNullish<[null, undefined, {}, []]>>().toEqualTypeOf<[{}, []]>()
+        expectTypeOf<utilities.FilterNonNullish<[null, undefined, { foo: string }, { bar: number }]>>().toEqualTypeOf<
+            [{ foo: string }, { bar: number }]
+        >()
+        expectTypeOf<utilities.FilterNonNullish<[null, undefined, () => void, () => void]>>().toEqualTypeOf<
+            [() => void, () => void]
+        >()
+        expectTypeOf<
+            utilities.FilterNonNullish<
+                [null, undefined, { foo: string; bar: undefined }, { bar: null; foo: { foobar: undefined } }]
+            >
+        >().toEqualTypeOf<[{ foo: string }, { foo: {} }]>()
+        expectTypeOf<
+            utilities.FilterNonNullish<
+                [{ foo: string; bar: [null, undefined, { foobar: [null, undefined, { barbar: [null, undefined] }] }] }]
+            >
+        >().toEqualTypeOf<[{ foo: string; bar: [{ foobar: [{ barbar: [] }] }] }]>()
+    })
+})

--- a/test/object-types.test.ts
+++ b/test/object-types.test.ts
@@ -1237,3 +1237,148 @@ describe("DeepNonNullable", () => {
         }>()
     })
 })
+
+describe("DeepNonNullish", () => {
+    test("Removes null and undefined values for all of the properties of an objects", () => {
+        expectTypeOf<
+            utilities.DeepNonNullish<{
+                foo: string
+                bar: null
+                foobar: {
+                    foo: undefined
+                    bar: string
+                    foobar: {
+                        foo: null
+                        bar: number
+                        foobar: {
+                            foo: undefined
+                            bar: string
+                            foobar: {
+                                bar: null
+                            }
+                        }
+                    }
+                }
+            }>
+        >().toEqualTypeOf<{
+            foo: string
+            foobar: {
+                bar: string
+                foobar: {
+                    bar: number
+                    foobar: {
+                        bar: string
+                        foobar: {}
+                    }
+                }
+            }
+        }>
+        type Nose = utilities.DeepNonNullish<{
+            foo: string
+            bar: null
+            foobar: {
+                foo: undefined
+                bar: string
+                foobar: [
+                    {
+                        foo: null
+                        bar: number
+                        foobar: {
+                            foo: undefined
+                            bar: string
+                            foobar: {
+                                bar: null
+                            }
+                        }
+                    },
+                    null,
+                    undefined,
+                ]
+            }
+        }>
+        expectTypeOf<
+            utilities.DeepNonNullish<{
+                foo: string
+                bar: null
+                foobar: {
+                    foo: undefined
+                    bar: string
+                    foobar: [
+                        {
+                            foo: null
+                            bar: number
+                            foobar: {
+                                foo: undefined
+                                bar: string
+                                foobar: {
+                                    bar: null
+                                }
+                            }
+                        },
+                        null,
+                        undefined,
+                    ]
+                }
+            }>
+        >().toEqualTypeOf<{
+            foo: string
+            foobar: {
+                bar: string
+                foobar: [
+                    {
+                        bar: number
+                        foobar: {
+                            bar: string
+                            foobar: {}
+                        }
+                    },
+                ]
+            }
+        }>
+        expectTypeOf<
+            utilities.DeepNonNullish<{
+                foo: string
+                bar: null
+                foobar: {
+                    foo: undefined
+                    bar: string
+                    foobar: [
+                        {
+                            foo: null
+                            bar: number
+                            foobar: {
+                                foo: undefined
+                                bar: string
+                                foobar: {
+                                    bar: null
+                                }
+                            }
+                        },
+                        null,
+                        undefined,
+                        {
+                            foo: [null, undefined, { bar: [null, undefined] }]
+                        },
+                    ]
+                }
+            }>
+        >().toEqualTypeOf<{
+            foo: string
+            foobar: {
+                bar: string
+                foobar: [
+                    {
+                        bar: number
+                        foobar: {
+                            bar: string
+                            foobar: {}
+                        }
+                    },
+                    {
+                        foo: [{ bar: [] }]
+                    },
+                ]
+            }
+        }>
+    })
+})


### PR DESCRIPTION
## Description

This pull request adds two new utility types called `DeepNonNullish` and `FilterNonNullish`. These two new utility types are useful to clean and remove nullish values of an object and an array. The two types are used with each other to complement the functionality of the two expected types.

### Key Changes
- Add `DeepNonNullish` utility type
- Add `FilterNoNullish` utility type

<!--Provide a detailed description or reasoning for the changes made -->

## Checklist

- [x] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
