### PR TITLE
fix(types): resolve conditional types in `DeepMerge` type

### DIFF
--- a/src/deep.ts
+++ b/src/deep.ts
@@ -47,7 +47,7 @@ export type DeepMerge<
                 ? Obj1[Property] | Obj2[Property]
                 : PriorityObject extends true
                   ? IsObject<Obj1[Property]> | IsObject<Obj2[Property]> extends true
-                      ? Prettify<DeepMerge<Obj1[Property] & {}, Obj2[Property] & {}>>
+                      ? Prettify<DeepMerge<Obj1[Property] & {}, Obj2[Property] & {}, ByUnion, PriorityObject>>
                       : IsObject<Obj1[Property]> extends true
                         ? Obj1[Property]
                         : IsObject<Obj2[Property]> extends true

--- a/src/deep.ts
+++ b/src/deep.ts
@@ -42,28 +42,23 @@ export type DeepMerge<
     PriorityObject extends boolean = true,
 > = {
     [Property in Properties<Obj1, Obj2>]: Property extends keyof Obj1
-        ? Obj1[Property] extends object
-            ? Property extends keyof Obj2
-                ? ByUnion extends true
-                    ? Obj1[Property] | Obj2[Property]
-                    : Obj2[Property] extends object
-                      ? Prettify<DeepMerge<Obj1[Property], Obj2[Property], ByUnion, PriorityObject>>
-                      : Obj1[Property]
-                : Obj1[Property]
-            : Property extends keyof Obj2
-              ? ByUnion extends true
-                  ? Obj1[Property] | Obj2[Property]
-                  : PriorityObject extends true
-                    ? Obj2[Property] extends object
-                        ? Obj2[Property]
-                        : Obj1[Property]
-                    : Obj1[Property]
-              : Obj1[Property]
+        ? Property extends keyof Obj2
+            ? ByUnion extends true
+                ? Obj1[Property] | Obj2[Property]
+                : PriorityObject extends true
+                  ? IsObject<Obj1[Property]> | IsObject<Obj2[Property]> extends true
+                      ? Prettify<DeepMerge<Obj1[Property] & {}, Obj2[Property] & {}>>
+                      : IsObject<Obj1[Property]> extends true
+                        ? Obj1[Property]
+                        : IsObject<Obj2[Property]> extends true
+                          ? Obj2[Property]
+                          : Obj1[Property]
+                  : Obj1[Property]
+            : Obj1[Property]
         : Property extends keyof Obj2
           ? Obj2[Property]
           : never
 }
-
 /**
  * @internal
  */

--- a/test/deep.test.ts
+++ b/test/deep.test.ts
@@ -73,6 +73,12 @@ describe("DeepMerge", () => {
                 }
             }
         }>()
+        expectTypeOf<
+            utilities.DeepMerge<
+                Case<DeepWithObjectsA, 3>,
+                { foo: boolean; foobar: { bar: () => void; foobar: { foo: string[] } } }
+            >
+        >().toEqualTypeOf<Case<DeepWithObjectsA, 3>>()
     })
 
     test("Merge two object types with union enabled", () => {
@@ -163,6 +169,91 @@ describe("DeepMerge", () => {
                           }
                       }
                   }
+        }>()
+    })
+    test("Merge two object types with priority object enabled", () => {
+        expectTypeOf<
+            utilities.DeepMerge<
+                Case<DeepWithObjectsA>,
+                {
+                    bar: {
+                        foo: string
+                    }
+                }
+            >
+        >().toEqualTypeOf<{
+            foo: string
+            bar: {
+                foo: string
+            }
+            foobar: {}
+        }>()
+        expectTypeOf<
+            utilities.DeepMerge<
+                Case<DeepWithObjectsA, 2>,
+                {
+                    bar: {
+                        foo: string
+                    }
+                    foobar: {
+                        bar: {
+                            fix: () => boolean[]
+                        }
+                    }
+                }
+            >
+        >().toEqualTypeOf<{
+            foo: string
+            bar: {
+                foo: string
+            }
+            foobar: {
+                foo: boolean
+                bar: {
+                    fix: () => boolean[]
+                }
+                foobar: {}
+            }
+        }>()
+        expectTypeOf<
+            utilities.DeepMerge<
+                Case<DeepWithFunctions>,
+                {
+                    fix: {
+                        fix: () => number
+                    }
+                }
+            >
+        >().toEqualTypeOf<{
+            fix: {
+                fix: () => number
+            }
+            foobar: {}
+        }>()
+        expectTypeOf<
+            utilities.DeepMerge<
+                Case<DeepWithFunctions, 2>,
+                {
+                    fix: {
+                        fix: () => number
+                    }
+                    foobar: {
+                        fix: {
+                            bar: () => string
+                        }
+                    }
+                }
+            >
+        >().toEqualTypeOf<{
+            fix: {
+                fix: () => number
+            }
+            foobar: {
+                fix: {
+                    bar: () => string
+                }
+                foobar: {}
+            }
         }>()
     })
 })
@@ -356,6 +447,35 @@ describe("DeepOmit", () => {
                         foobar: {
                             bar: number
                         }
+                    }
+                }
+            }
+        }>()
+        expectTypeOf<utilities.DeepOmit<Case<DeepWithFunctions>, "foobar">>().toEqualTypeOf<{ fix: () => number }>()
+        expectTypeOf<utilities.DeepOmit<DeepWithFunctions, "fix" | "foobar.fix" | "foobar.foobar.fix">>().toEqualTypeOf<{
+            foobar: {
+                foobar: {
+                    foobar: {
+                        fix: () => symbol
+                        foobar: {
+                            fix: () => bigint
+                        }
+                    }
+                }
+            }
+        }>()
+        expectTypeOf<utilities.DeepOmit<Case<DeepWithArray>, "buz">>().toEqualTypeOf<{
+            foobar: {}
+        }>()
+        expectTypeOf<
+            utilities.DeepOmit<DeepWithArray, "buz" | "foobar.foobar.buz" | "foobar.foobar.foobar.foobar.buz">
+        >().toEqualTypeOf<{
+            foobar: {
+                buz: number[]
+                foobar: {
+                    foobar: {
+                        buz: symbol[]
+                        foobar: {}
                     }
                 }
             }


### PR DESCRIPTION
## Description

This pull request improves the `DeepMerge` type by resolving issues with conditional type checks for nested object values. Previously, certain object structures were not matched correctly, leading to inaccurate type inference.

Additionally, the `PriorityObject` type has been fixed to behave as originally intended.

New utility types were also added to verify which types are supported by the updated implementation and which were not supported in the previous version. These additions help ensure improved type safety and better developer experience.

## Checklist

- [x] Added documentation  
- [x] The changes do not generate any warnings  
- [ ] I have performed a self-review of my own code  
- [ ] All tests have been added and pass successfully  

## Notes
