### PR TITLE
feat(types): add `DeepUnion` type

### DIFF
--- a/src/deep.ts
+++ b/src/deep.ts
@@ -59,6 +59,30 @@ export type DeepMerge<
           ? Obj2[Property]
           : never
 }
+
+/**
+ * Create a merge of the union type of the values of the two object. This types implements the
+ * `DeepMerge` type with the third argument `ByUnion` as a true. This type is an abstraction
+ * version of `DeepMerge`
+ *
+ * @param {object} Obj1 - The first object to merge
+ * @param {object} Obj2 - The second object to merge
+ * @example
+ * interface BaseController {
+ *   baseUrl: string
+ *   routes: string[]
+ * }
+ *
+ * interface ConfigBase {
+ *   baseUrl: string[]
+ *   routes: Array<{ url: string, name: string }>
+ * }
+ *
+ * // Expected: { baseUrl: string | string[], routes: string[] | Array<{ url: string, name: string }> }
+ * type Union = DeepUnion<BaseController, ConfigBase>
+ */
+export type DeepUnion<Obj1 extends object, Obj2 extends object> = DeepMerge<Obj1, Obj2, true>
+
 /**
  * @internal
  */

--- a/test/deep.test.ts
+++ b/test/deep.test.ts
@@ -92,6 +92,16 @@ describe("DeepMerge", () => {
             bar: boolean
             foobar: {}
         }>()
+        expectTypeOf<
+            utilities.DeepMerge<
+                { baseUrl: string; routes: string[] },
+                { baseUrl: string[]; routes: Array<{ url: string; name: string }> },
+                true
+            >
+        >().toEqualTypeOf<{
+            baseUrl: string | string[]
+            routes: string[] | Array<{ url: string; name: string }>
+        }>()
         expectTypeOf<utilities.DeepMerge<Case<DeepWithObjectsA>, Case<DeepWithObjectsB>, true>>().toEqualTypeOf<{
             foo: string
             bar: number | boolean


### PR DESCRIPTION
## Description

This pull request introduces the `DeepUnion` type, which wraps the existing `DeepMerge` utility type from the library. It provides an abstraction of `DeepMerge` with the third type parameter (`ByUnion`) set to `true`, enabling deep merging with union behavior for conflicting properties.

For more information about the underlying logic, refer to the `DeepMerge` type documentation within the library.

## Checklist

- [x] Added documentation  
- [x] The changes do not generate any warnings  
- [ ] I have performed a self-review of my own code  
- [ ] All tests have been added and pass successfully  

## Notes

<!-- Add any additional relevant information here -->
