### PR TITLE
chore(ci): update ubuntu version

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   release:
     if: github.event.pull_request.merged == true && github.base_ref == 'master' && startsWith(github.head_ref, 'release/')
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     environment: production
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Description

This pull request updates the Ubuntu version to the latest supported release because the previous version, `20.04`, has been deprecated and is no longer maintained. The deprecation of this version caused the cancellation of workflows that depended on it, which in turn prevented the release of version `v0.20.0` of the package.

## Checklist

- [ ] Added documentation.
- [x] The changes do not generate any warnings.
- [x] I have performed a self-review of my own code
- [x] All tests have been added and pass successfully

## Notes

<!-- Add any additional relevant information here -->
